### PR TITLE
Fix repo path

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -22,8 +22,7 @@ from configparser import RawConfigParser, NoSectionError
 from invoke import task, Exit
 
 
-# This is the symlink path in the repo
-REPO_PATH = os.path.dirname(__file__)
+REPO_PATH = os.path.dirname(os.path.dirname(__file__))
 SETUP_SECTION = 'tool:release'
 
 # Label class used below for setup-labels


### PR DESCRIPTION
It was pointed into `/common` for some reason, requiring the use of
`--path` for prepare. It should be handled automatically.