### PR TITLE
Bring docker files to share them across repos

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+../../docker/common.sh
+
+CMD='python3 -m celery worker -A readthedocs.worker -Ofair -c 2 -Q builder,celery,default,build01 -l DEBUG'
+
+if [ -n "${DOCKER_NO_RELOAD}" ]; then
+  echo "Running Docker with no reload"
+  $CMD
+else
+  echo "Running Docker with reload"
+  watchmedo auto-restart \
+  --patterns="*.py" \
+  --ignore-patterns="*.#*.py;./user_builds/*;./public_*;./private_*;*.pyo;*.pyc;*flycheck*.py;./media/*;./.tox/*" \
+  --ignore-directories \
+  --recursive \
+  --signal=SIGTERM \
+  --kill-after=5 \
+  --interval=5 \
+  -- \
+  $CMD
+fi

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -19,6 +19,6 @@ else
   --signal=SIGTERM \
   --kill-after=5 \
   --interval=5 \
-  -- 
+  -- \
   $CMD
 fi

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+../../docker/common.sh
+
+python3 ../../docker/scripts/wait_for_search.py
+
+CMD='python3 -m celery worker -A readthedocs.worker -Ofair -c 2 -Q web,web01,reindex -l DEBUG'
+
+if [ -n "${DOCKER_NO_RELOAD}" ]; then
+  echo "Running Docker with no reload"
+  $CMD
+else
+  echo "Running Docker with reload"
+  watchmedo auto-restart \
+  --patterns="*.py" \
+  --ignore-patterns="*.#*.py;./user_builds/*;./public_*;./private_*;*.pyo;*.pyc;*flycheck*.py;./media/*;./.tox/*" \
+  --ignore-directories \
+  --recursive \
+  --signal=SIGTERM \
+  --kill-after=5 \
+  --interval=5 \
+  -- 
+  $CMD
+fi

--- a/dockerfiles/entrypoints/common.sh
+++ b/dockerfiles/entrypoints/common.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# This file is useful when you need to run a command on all the Python
+# instances and you don't want to rebuild the image. For example, when
+# working on a feature that requires a new dependency and you need to
+# call: "pip install newdependency==1.4.2". You can add that command
+# here, and it will be executed in all the instances at startup.

--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+../../docker/common.sh
+
+if [ -n "${DOCKER_NO_RELOAD}" ];
+then
+    RELOAD='--noreload'
+    echo "Running Docker with no reload"
+else
+    RELOAD=''
+    echo "Running Docker with reload"
+fi
+
+python3 manage.py runserver 0.0.0.0:8000 $RELOAD

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -1,0 +1,23 @@
+#! /bin/sh
+
+../../docker/common.sh
+
+if [ -n "$INIT" ];
+then
+    echo "Performing initial tasks..."
+    python3 manage.py migrate
+    cat ../../docker/createsuperuser.py | python3 manage.py shell
+    python3 manage.py collectstatic --no-input
+    python3 manage.py loaddata test_data
+fi
+
+if [ -n "${DOCKER_NO_RELOAD}" ];
+then
+    RELOAD='--noreload'
+    echo "Running Docker with no reload"
+else
+    RELOAD=''
+    echo "Running Docker with reload"
+fi
+
+python3 manage.py runserver 0.0.0.0:8000 $RELOAD

--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,0 +1,3 @@
+# requirements file to lunch Read the Docs using docker-compose
+invoke==1.3.0
+docker-compose==1.25.0

--- a/dockerfiles/scripts/create-containers.sh
+++ b/dockerfiles/scripts/create-containers.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+az storage container create --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://storage:10000/devstoreaccount1" --public-access "blob" --name "builds"
+az storage container create --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://storage:10000/devstoreaccount1" --public-access "blob" --name "media"
+az storage container create --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://storage:10000/devstoreaccount1" --public-access "blob" --name "static"

--- a/dockerfiles/scripts/createsuperuser.py
+++ b/dockerfiles/scripts/createsuperuser.py
@@ -1,0 +1,4 @@
+from django.contrib.auth.models import User
+
+if not User.objects.filter(username='admin').exists():
+    User.objects.create_superuser('admin', 'admin@admin.com', 'admin')

--- a/dockerfiles/scripts/wait_for_search.py
+++ b/dockerfiles/scripts/wait_for_search.py
@@ -1,0 +1,20 @@
+import os
+import time
+import requests
+
+wait_sleep = 3
+max_loops = 15
+
+loops = 1
+if 'SEARCH' in os.environ:
+    while loops < max_loops:
+        try:
+            print('Waiting for search service...')
+            response = requests.get('http://search:9200/_cluster/health')
+            if response.status_code == 200:
+                print('Search is ready!')
+                break
+            loops += 1
+        except:
+            pass
+        time.sleep(wait_sleep)

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -1,0 +1,86 @@
+from invoke import task
+
+DOCKER_COMPOSE = 'docker-compose.yml'
+DOCKER_COMPOSE_SEARCH = 'docker-compose-search.yml'
+DOCKER_COMPOSE_COMMAND = f'docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_SEARCH}'
+
+@task
+def build(c):
+    """Build docker image for servers."""
+    c.run(f'{DOCKER_COMPOSE_COMMAND} build --no-cache', pty=True)
+
+@task
+def down(c, volumes=False):
+    """Stop and remove all the docker containers."""
+    if volumes:
+        c.run(f'{DOCKER_COMPOSE_COMMAND} down -v', pty=True)
+    else:
+        c.run(f'{DOCKER_COMPOSE_COMMAND} down', pty=True)
+
+
+@task
+def up(c, no_search=False, init=False, no_reload=False):
+    """Start all the docker containers for a Read the Docs instance"""
+    INIT = 'INIT='
+    DOCKER_NO_RELOAD = 'DOCKER_NO_RELOAD='
+    if init:
+        INIT = 'INIT=t'
+    if no_reload:
+        DOCKER_NO_RELOAD = 'DOCKER_NO_RELOAD=t'
+
+    if no_search:
+        c.run(f'{INIT} {DOCKER_NO_RELOAD} docker-compose -f {DOCKER_COMPOSE} up', pty=True)
+    else:
+        c.run(f'{INIT} {DOCKER_NO_RELOAD} {DOCKER_COMPOSE_COMMAND} up', pty=True)
+
+
+@task
+def shell(c, running=False, container='web'):
+    """Run a shell inside a container."""
+    if running:
+        c.run(f'{DOCKER_COMPOSE_COMMAND} exec {container} /bin/bash', pty=True)
+    else:
+        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm {container} /bin/bash', pty=True)
+
+@task
+def manage(c, command):
+    """Run manage.py with a specific command."""
+    c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web python3 manage.py {command}', pty=True)
+
+@task
+def attach(c, container):
+    """Attach a tty to a running container (useful for pdb)."""
+    c.run(f'docker attach readthedocsorg_{container}_1', pty=True)
+
+@task
+def restart(c, containers):
+    """Restart one or more containers."""
+    c.run(f'{DOCKER_COMPOSE_COMMAND} restart {containers}', pty=True)
+
+    # When restarting a container that nginx is connected to, we need to restart
+    # nginx as well because it has the IP cached
+    need_nginx_restart = [
+        'web',
+        'proxito'
+        'storage',
+    ]
+    for extra in need_nginx_restart:
+        if extra in containers:
+            c.run(f'{DOCKER_COMPOSE_COMMAND} restart nginx', pty=True)
+            break
+
+@task
+def pull(c):
+    """Pull all docker images required for build servers."""
+    images = [
+        ('4.0', 'stable'),
+        ('5.0', 'latest'),
+    ]
+    for image, tag in images:
+        c.run(f'docker pull readthedocs/build:{image}', pty=True)
+        c.run(f'docker tag readthedocs/build:{image} readthedocs/build:{tag}', pty=True)
+
+@task
+def test(c, arguments=''):
+    """Run all test suite."""
+    c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm --no-deps web tox {arguments}', pty=True)

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -50,7 +50,8 @@ def manage(c, command):
 @task
 def attach(c, container):
     """Attach a tty to a running container (useful for pdb)."""
-    c.run(f'docker attach readthedocsorg_{container}_1', pty=True)
+    prefix = c['container_prefix'] # readthedocsorg or readthedocs-corporate
+    c.run(f'docker attach {prefix}_{container}_1', pty=True)
 
 @task
 def restart(c, containers):

--- a/tasks.py
+++ b/tasks.py
@@ -17,7 +17,6 @@ import os
 import textwrap
 from collections import namedtuple
 
-from dateutil.parser import parse
 from configparser import RawConfigParser, NoSectionError
 from invoke import task, Exit
 
@@ -43,6 +42,13 @@ def prepare(ctx, version, path=REPO_PATH, since=None):
     updated.  New entries will end up at the top of the file, under a heading
     for the new version.
     """
+
+    try:
+        from dateutil.parser import parse
+    except ImportError:
+        print('You need to install `python-dateutil` package: "pip install python-dateutil"')
+        raise Exit(1)
+
     print('Updating release version in setup.cfg')
     setupcfg_path = os.path.join(path, 'setup.cfg')
     config = RawConfigParser()


### PR DESCRIPTION
Bring Docker tasks, entrypoints and scripts to common repository so we can use them from .org and .com.

Needed by https://github.com/readthedocs/readthedocs.org/pull/6471 and https://github.com/readthedocs/readthedocs-corporate/pull/767

> Once this PR is merged, we need to upgrade `common` submodule in the other repositories