### PR TITLE
Do not send events to container when attach

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -51,7 +51,7 @@ def manage(c, command):
 def attach(c, container):
     """Attach a tty to a running container (useful for pdb)."""
     prefix = c['container_prefix'] # readthedocsorg or readthedocs-corporate
-    c.run(f'docker attach {prefix}_{container}_1', pty=True)
+    c.run(f'docker attach --sig-proxy=false {prefix}_{container}_1', pty=True)
 
 @task
 def restart(c, containers):


### PR DESCRIPTION
This allows us to detach the container using CTRL+p CTRL+q without killing the running process.

See https://docs.docker.com/engine/reference/commandline/attach/