### PR TITLE
Bring docker-compose common configuration files

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -1,0 +1,30 @@
+# docker-compose-search.yml starts "search" service and override some
+# services to link them so they can use the "search" as well.
+version: '3'
+
+volumes:
+  search_data:
+
+services:
+
+  celery:
+    environment:
+      - SEARCH=t
+
+  # You may need to increase the memory for vm
+  # sudo sysctl -w vm.max_map_count=262144
+  search:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    environment:
+      - discovery.type=single-node
+      - node.name=search
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.info.update.interval=30m
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    links:
+      - web
+      - celery
+    volumes:
+      - search_data:/usr/share/elasticsearch/data
+    networks:
+      readthedocs:

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     volumes:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/proxito.sh:/usr/src/app/docker/proxito.sh
-      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
       - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
     links:
       - storage
@@ -55,8 +54,6 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/web.sh:/usr/src/app/docker/web.sh
       - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/web.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/web.py
     links:
       - storage
       - database
@@ -79,8 +76,6 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/celery.sh:/usr/src/app/docker/celery.sh
       - ${PWD}/common/dockerfiles/scripts/wait_for_search.py:/usr/src/app/docker/scripts/wait_for_search.py
       - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/celery.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/celery.py
     links:
       - storage
       - database
@@ -101,8 +96,6 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/build.sh:/usr/src/app/docker/build.sh
       - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/build.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/build.py
 
       # The python code at readthedocs/doc_builder/environments.py
       # mounts `self.project.doc_path`. We need to share this path

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -1,0 +1,143 @@
+version: '3'
+
+volumes:
+  build-user-builds:
+  storage_data:
+  postgres_data:
+  postgres_backups_data:
+
+services:
+
+  server:
+    # Image used for all the other services (proxito, web, celery, build)
+    build:
+      context: .
+      dockerfile: ${PWD}/dockerfiles/Dockerfile
+
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+    links:
+      - web
+      - proxito
+      - storage
+    volumes:
+      - ${PWD}/dockerfiles/nginx:/etc/nginx/conf.d
+
+  proxito:
+    image: readthedocsorg_server:latest
+    volumes:
+      - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
+      - ${PWD}/common/dockerfiles/entrypoints/proxito.sh:/usr/src/app/docker/proxito.sh
+      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
+      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+    links:
+      - storage
+      - database
+      - cache
+    environment:
+      - DOCKER_NO_RELOAD
+
+    # Allow us to run `docker attach readthedocsorg_proxito_1` and get
+    # control on STDIN and be able to debug our code with interactive pdb
+    stdin_open: true
+    tty: true
+
+    networks:
+      readthedocs:
+    command: ["../../docker/proxito.sh"]
+
+  web:
+    image: readthedocsorg_server:latest
+    volumes:
+      - ${PWD}/common/dockerfiles/scripts/createsuperuser.py:/usr/src/app/docker/createsuperuser.py
+      - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
+      - ${PWD}/common/dockerfiles/entrypoints/web.sh:/usr/src/app/docker/web.sh
+      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
+      - ${PWD}/dockerfiles/settings/web.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/web.py
+    links:
+      - storage
+      - database
+      - cache
+    depends_on:
+      - storage
+    environment:
+      - INIT=${INIT:-}
+      - DOCKER_NO_RELOAD
+    stdin_open: true
+    tty: true
+    networks:
+      readthedocs:
+    command: ["../../docker/web.sh"]
+
+  celery:
+    image: readthedocsorg_server:latest
+    volumes:
+      - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
+      - ${PWD}/common/dockerfiles/entrypoints/celery.sh:/usr/src/app/docker/celery.sh
+      - ${PWD}/common/dockerfiles/scripts/wait_for_search.py:/usr/src/app/docker/scripts/wait_for_search.py
+      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
+      - ${PWD}/dockerfiles/settings/celery.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/celery.py
+    links:
+      - storage
+      - database
+      - cache
+    depends_on:
+      - storage
+    environment:
+      - DOCKER_NO_RELOAD
+    stdin_open: true
+    tty: true
+    networks:
+      readthedocs:
+    command: ["../../docker/celery.sh"]
+
+  build:
+    image: readthedocsorg_server:latest
+    volumes:
+      - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
+      - ${PWD}/common/dockerfiles/entrypoints/build.sh:/usr/src/app/docker/build.sh
+      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}:/usr/src/app/checkouts/readthedocs.org
+      - ${PWD}/dockerfiles/settings/build.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/build.py
+
+      # The python code at readthedocs/doc_builder/environments.py
+      # mounts `self.project.doc_path`. We need to share this path
+      # between the build container (git commands), and the container that
+      # is created inside the build container (sphinx commands).
+      # Because of this, we need to use a shared volume between them
+      - build-user-builds:/usr/src/app/checkouts/readthedocs.org/user_builds
+
+      # Docker in Docker
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - web
+      - storage
+      - cache
+    environment:
+      - DOCKER_NO_RELOAD
+    stdin_open: true
+    tty: true
+    networks:
+      readthedocs:
+    command: ["../../docker/build.sh"]
+
+  cache:
+    image: redis:3.2.7
+    networks:
+      readthedocs:
+
+  database:
+    image: postgres:11.1
+    environment:
+      - POSTGRES_USER=docs_user
+      - POSTGRES_PASSWORD=docs_pwd
+      - POSTGRES_DB=docs_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - postgres_backups_data:/backups
+    networks:
+      readthedocs:

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -1,8 +1,9 @@
 from invoke import task
 
-DOCKER_COMPOSE = 'docker-compose.yml'
+DOCKER_COMPOSE = 'common/dockerfiles/docker-compose.yml'
 DOCKER_COMPOSE_SEARCH = 'docker-compose-search.yml'
-DOCKER_COMPOSE_COMMAND = f'docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_SEARCH}'
+DOCKER_COMPOSE_OVERRIDE = 'docker-compose.override.yml'
+DOCKER_COMPOSE_COMMAND = f'docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_OVERRIDE} -f {DOCKER_COMPOSE_SEARCH}'
 
 @task
 def build(c):
@@ -17,7 +18,6 @@ def down(c, volumes=False):
     else:
         c.run(f'{DOCKER_COMPOSE_COMMAND} down', pty=True)
 
-
 @task
 def up(c, no_search=False, init=False, no_reload=False):
     """Start all the docker containers for a Read the Docs instance"""
@@ -29,7 +29,7 @@ def up(c, no_search=False, init=False, no_reload=False):
         DOCKER_NO_RELOAD = 'DOCKER_NO_RELOAD=t'
 
     if no_search:
-        c.run(f'{INIT} {DOCKER_NO_RELOAD} docker-compose -f {DOCKER_COMPOSE} up', pty=True)
+        c.run(f'{INIT} {DOCKER_NO_RELOAD} docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_OVERRIDE} up', pty=True)
     else:
         c.run(f'{INIT} {DOCKER_NO_RELOAD} {DOCKER_COMPOSE_COMMAND} up', pty=True)
 

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -1,7 +1,7 @@
 from invoke import task
 
 DOCKER_COMPOSE = 'common/dockerfiles/docker-compose.yml'
-DOCKER_COMPOSE_SEARCH = 'docker-compose-search.yml'
+DOCKER_COMPOSE_SEARCH = 'common/dockerfiles/docker-compose-search.yml'
 DOCKER_COMPOSE_OVERRIDE = 'docker-compose.override.yml'
 DOCKER_COMPOSE_COMMAND = f'docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_OVERRIDE} -f {DOCKER_COMPOSE_SEARCH}'
 


### PR DESCRIPTION
Most of the configs for docker-compose can be shared between community and corporate. This PR bring all the common ones into this repo.