### PR TITLE
Reduce search container ram to 128Mb

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -20,7 +20,7 @@ services:
       - node.name=search
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.info.update.interval=30m
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms128m -Xmx128m"
     links:
       - web
       - celery


### PR DESCRIPTION
There is no need to use 512Mb.

Container memory is reduced from ~800 to ~400.