### PR TITLE
`compose` task to pass the command directly to docker-compose

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -11,6 +11,11 @@ def build(c):
     c.run(f'{DOCKER_COMPOSE_COMMAND} build --no-cache', pty=True)
 
 @task
+def compose(c, command):
+    """Pass the command to docker-compose directly."""
+    c.run(f'{DOCKER_COMPOSE_COMMAND} {command}', pty=True)
+
+@task
 def down(c, volumes=False):
     """Stop and remove all the docker containers."""
     if volumes:


### PR DESCRIPTION
This can be used as `inv docker.compose 'stop nginx'` for example.

It's just a helper to call docker-compose without specifying all the
.yaml files by hand.