### PR TITLE
Add ext-theme and path configuration

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     volumes:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/proxito.sh:/usr/src/app/docker/proxito.sh
-      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
     links:
       - storage
       - database
@@ -51,7 +52,8 @@ services:
       - ${PWD}/common/dockerfiles/scripts/createsuperuser.py:/usr/src/app/docker/createsuperuser.py
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/web.sh:/usr/src/app/docker/web.sh
-      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
     links:
       - storage
       - database
@@ -61,6 +63,7 @@ services:
     environment:
       - INIT=${INIT:-}
       - DOCKER_NO_RELOAD
+      - RTD_EXT_THEME_ENABLED
     stdin_open: true
     tty: true
     networks:
@@ -72,7 +75,8 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/celery.sh:/usr/src/app/docker/celery.sh
       - ${PWD}/common/dockerfiles/scripts/wait_for_search.py:/usr/src/app/docker/scripts/wait_for_search.py
-      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
     links:
       - storage
       - database
@@ -91,7 +95,8 @@ services:
     volumes:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/build.sh:/usr/src/app/docker/build.sh
-      - ${PWD}/../readthedocs-ext:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
 
       # The python code at readthedocs/doc_builder/environments.py
       # mounts `self.project.doc_path`. We need to share this path

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/proxito.sh:/usr/src/app/docker/proxito.sh
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
     links:
       - storage
       - database
@@ -53,7 +53,7 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/web.sh:/usr/src/app/docker/web.sh
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
     links:
       - storage
       - database
@@ -76,7 +76,7 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/celery.sh:/usr/src/app/docker/celery.sh
       - ${PWD}/common/dockerfiles/scripts/wait_for_search.py:/usr/src/app/docker/scripts/wait_for_search.py
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
     links:
       - storage
       - database
@@ -96,7 +96,7 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/build.sh:/usr/src/app/docker/build.sh
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
-      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
 
       # The python code at readthedocs/doc_builder/environments.py
       # mounts `self.project.doc_path`. We need to share this path


### PR DESCRIPTION
I would prefer configurable paths here. If you set environment variables
RTDDEV_PATH_*, this will bubble up to docker compose.

There will be two related PRs that enable theme usage: one for community
and one for corporate.