### PR TITLE
Expose ES to the local machine

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -21,6 +21,8 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.info.update.interval=30m
       - "ES_JAVA_OPTS=-Xms128m -Xmx128m"
+    ports:
+      - "9200:9200"
     links:
       - web
       - celery


### PR DESCRIPTION
This will help with debugging of ES issues,
and let us query it directly instead of having to use a docker shell.