### PR TITLE
Reduce number of files watched by watchmedo

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -16,6 +16,9 @@ else
   --ignore-patterns="*.pyo" \
   --ignore-patterns="*.pyc" \
   --ignore-patterns="*flycheck*.py" \
+  --ignore-patterns="*test*" \
+  --ignore-patterns="*migrations*" \
+  --ignore-patterns="*management/commands*" \
   --ignore-directories \
   --recursive \
   --signal=SIGTERM \

--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -10,8 +10,8 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="readthedocs/*.py" \
-  --patterns="readthedocsinc/*.py" \
+  --patterns="./readthedocs/*.py" \
+  --patterns="./readthedocsinc/*.py" \
   --ignore-patterns="*.#*.py" \
   --ignore-patterns="*.pyo" \
   --ignore-patterns="*.pyc" \

--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -10,8 +10,12 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="*.py" \
-  --ignore-patterns="*.#*.py;./user_builds/*;./public_*;./private_*;*.pyo;*.pyc;*flycheck*.py;./media/*;./.tox/*" \
+  --patterns="readthedocs/*.py" \
+  --patterns="readthedocsinc/*.py" \
+  --ignore-patterns="*.#*.py" \
+  --ignore-patterns="*.pyo" \
+  --ignore-patterns="*.pyc" \
+  --ignore-patterns="*flycheck*.py" \
   --ignore-directories \
   --recursive \
   --signal=SIGTERM \

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -18,6 +18,9 @@ else
   --ignore-patterns="*.pyo" \
   --ignore-patterns="*.pyc" \
   --ignore-patterns="*flycheck*.py" \
+  --ignore-patterns="*test*" \
+  --ignore-patterns="*migrations*" \
+  --ignore-patterns="*management/commands*" \
   --ignore-directories \
   --recursive \
   --signal=SIGTERM \

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -12,8 +12,12 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="*.py" \
-  --ignore-patterns="*.#*.py;./user_builds/*;./public_*;./private_*;*.pyo;*.pyc;*flycheck*.py;./media/*;./.tox/*" \
+  --patterns="readthedocs/*.py" \
+  --patterns="readthedocsinc/*.py" \
+  --ignore-patterns="*.#*.py" \
+  --ignore-patterns="*.pyo" \
+  --ignore-patterns="*.pyc" \
+  --ignore-patterns="*flycheck*.py" \
   --ignore-directories \
   --recursive \
   --signal=SIGTERM \

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -12,8 +12,8 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="readthedocs/*.py" \
-  --patterns="readthedocsinc/*.py" \
+  --patterns="./readthedocs/*.py" \
+  --patterns="./readthedocsinc/*.py" \
   --ignore-patterns="*.#*.py" \
   --ignore-patterns="*.pyo" \
   --ignore-patterns="*.pyc" \


### PR DESCRIPTION
Only watch `readthedocs/*.py` and `readthedocsinc/*.py`. This may help
a little with the CPU usage when running with reload enabled.