### PR TITLE
Rely on Django web app to reload Python modules via pool_restart

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -2,21 +2,4 @@
 
 ../../docker/common.sh
 
-CMD="python3 -m celery worker -A ${CELERY_APP_NAME}.worker -Ofair -c 2 -Q builder,celery,default,build01 -l DEBUG"
-
-if [ -n "${DOCKER_NO_RELOAD}" ]; then
-  echo "Running Docker with no reload"
-  $CMD
-else
-  echo "Running Docker with reload"
-  watchmedo auto-restart \
-  --patterns="*.py" \
-  --ignore-patterns="*.#*.py;./user_builds/*;./public_*;./private_*;*.pyo;*.pyc;*flycheck*.py;./media/*;./.tox/*" \
-  --ignore-directories \
-  --recursive \
-  --signal=SIGTERM \
-  --kill-after=5 \
-  --interval=5 \
-  -- \
-  $CMD
-fi
+python3 -m celery worker -A ${CELERY_APP_NAME}.worker -Ofair -c 2 -Q builder,celery,default,build01 -l DEBUG

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -4,21 +4,4 @@
 
 python3 ../../docker/scripts/wait_for_search.py
 
-CMD="python3 -m celery worker -A ${CELERY_APP_NAME}.worker -Ofair -c 2 -Q web,web01,reindex -l DEBUG"
-
-if [ -n "${DOCKER_NO_RELOAD}" ]; then
-  echo "Running Docker with no reload"
-  $CMD
-else
-  echo "Running Docker with reload"
-  watchmedo auto-restart \
-  --patterns="*.py" \
-  --ignore-patterns="*.#*.py;./user_builds/*;./public_*;./private_*;*.pyo;*.pyc;*flycheck*.py;./media/*;./.tox/*" \
-  --ignore-directories \
-  --recursive \
-  --signal=SIGTERM \
-  --kill-after=5 \
-  --interval=5 \
-  -- \
-  $CMD
-fi
+python3 -m celery worker -A ${CELERY_APP_NAME}.worker -Ofair -c 2 -Q web,web01,reindex -l DEBUG


### PR DESCRIPTION
This is a different approach to #56 that it's simpler and use Celery internals to reload all Python modules instead of killing and re-starting the whole process.

See https://github.com/readthedocs/readthedocs.org/pull/6812