### PR TITLE
Consume from new 'build:' queues

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="python3 -m celery worker -A ${CELERY_APP_NAME}.worker -Ofair -c 2 -Q builder,celery,default,build01 -l DEBUG"
+CMD="python3 -m celery worker -A ${CELERY_APP_NAME}.worker -Ofair -c 2 -Q build:default,build:large -l DEBUG"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running Docker with no reload"


### PR DESCRIPTION
Make builders consume from the new queue names. See https://github.com/readthedocs/readthedocs.org/pull/6853