### PR TITLE
 Add docker and docker task support for using ext-theme

### DIFF
--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -7,17 +7,15 @@ services:
   webpack:
     image: node:12
     working_dir: /usr/src/app/checkouts/ext-theme
-    environment:
-      - NODE_ENV=development
     ports:
       - "10001:10001"
     volumes:
-      - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
       - ${PWD}/common/dockerfiles/entrypoints/webpack.sh:/usr/src/app/docker/webpack.sh
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
     environment:
       - INIT=${INIT:-}
       - DOCKER_NO_RELOAD
+      - NODE_ENV=development
       - RTD_EXT_THEME_ENABLED
       - RTD_EXT_THEME_DEV_SERVER_ENABLED
     stdin_open: true

--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -11,7 +11,7 @@ services:
       - "10001:10001"
     volumes:
       - ${PWD}/common/dockerfiles/entrypoints/webpack.sh:/usr/src/app/docker/webpack.sh
-      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
     environment:
       - INIT=${INIT:-}
       - DOCKER_NO_RELOAD

--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -1,0 +1,27 @@
+# docker-compose-webpack.yml starts Webpack dev server for hot reload of built
+# static assets.
+version: '3'
+
+services:
+
+  webpack:
+    image: node:12
+    working_dir: /usr/src/app/checkouts/ext-theme
+    environment:
+      - NODE_ENV=development
+    ports:
+      - "10001:10001"
+    volumes:
+      - ${PWD}/common/dockerfiles/entrypoints/common.sh:/usr/src/app/docker/common.sh
+      - ${PWD}/common/dockerfiles/entrypoints/webpack.sh:/usr/src/app/docker/webpack.sh
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../readthedocs-ext-theme}:/usr/src/app/checkouts/ext-theme
+    environment:
+      - INIT=${INIT:-}
+      - DOCKER_NO_RELOAD
+      - RTD_EXT_THEME_ENABLED
+      - RTD_EXT_THEME_DEV_SERVER_ENABLED
+    stdin_open: true
+    tty: true
+    networks:
+      readthedocs:
+    command: ["../../docker/webpack.sh"]

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - INIT=${INIT:-}
       - DOCKER_NO_RELOAD
       - RTD_EXT_THEME_ENABLED
+      - RTD_EXT_THEME_DEV_SERVER_ENABLED
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/entrypoints/webpack.sh
+++ b/dockerfiles/entrypoints/webpack.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+npm install
+
+$(npm bin)/webpack-dev-server \
+  --mode=development \
+  --host=0.0.0.0 \
+  --port=10001

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -33,8 +33,9 @@ def down(c, volumes=False):
     'reload': 'Enable automatic process reloading (default: True)',
     'webpack': 'Start webpack development server (default: False)',
     'ext-theme-enabled': 'Enable new theme from ext-theme (default: False)',
+    'scale-build': 'Add additional build instances (default: 1)',
 })
-def up(c, search=True, init=False, reload=True, webpack=False, ext_theme_enabled=False):
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme_enabled=False, scale_build=1):
     """Start all the docker containers for a Read the Docs instance"""
     cmd = []
 
@@ -56,6 +57,8 @@ def up(c, search=True, init=False, reload=True, webpack=False, ext_theme_enabled
         cmd.insert(0, 'RTD_EXT_THEME_ENABLED=t')
 
     cmd.append('up')
+
+    cmd.append(f'--scale build={scale_build}')
 
     c.run(' '.join(cmd), pty=True)
 

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -32,10 +32,10 @@ def down(c, volumes=False):
     'init': 'Perform initialization steps (default: False)',
     'reload': 'Enable automatic process reloading (default: True)',
     'webpack': 'Start webpack development server (default: False)',
-    'ext-theme-enabled': 'Enable new theme from ext-theme (default: False)',
+    'ext-theme': 'Enable new theme from ext-theme (default: False)',
     'scale-build': 'Add additional build instances (default: 1)',
 })
-def up(c, search=True, init=False, reload=True, webpack=False, ext_theme_enabled=False, scale_build=1):
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1):
     """Start all the docker containers for a Read the Docs instance"""
     cmd = []
 
@@ -50,10 +50,10 @@ def up(c, search=True, init=False, reload=True, webpack=False, ext_theme_enabled
         cmd.append(f'-f {DOCKER_COMPOSE_SEARCH}')
     if webpack:
         # This option implies the theme is enabled automatically
-        ext_theme_enabled = True
+        ext_theme = True
         cmd.append(f'-f {DOCKER_COMPOSE_WEBPACK}')
         cmd.insert(0, 'RTD_EXT_THEME_DEV_SERVER_ENABLED=t')
-    if ext_theme_enabled:
+    if ext_theme:
         cmd.insert(0, 'RTD_EXT_THEME_ENABLED=t')
 
     cmd.append('up')

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -2,8 +2,9 @@ from invoke import task
 
 DOCKER_COMPOSE = 'common/dockerfiles/docker-compose.yml'
 DOCKER_COMPOSE_SEARCH = 'common/dockerfiles/docker-compose-search.yml'
+DOCKER_COMPOSE_WEBPACK = 'common/dockerfiles/docker-compose-webpack.yml'
 DOCKER_COMPOSE_OVERRIDE = 'docker-compose.override.yml'
-DOCKER_COMPOSE_COMMAND = f'docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_OVERRIDE} -f {DOCKER_COMPOSE_SEARCH}'
+DOCKER_COMPOSE_COMMAND = f'docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_OVERRIDE} -f {DOCKER_COMPOSE_SEARCH} -f {DOCKER_COMPOSE_WEBPACK}'
 
 @task(help={
     'cache': 'Build Docker image using cache (default: False)',
@@ -26,21 +27,38 @@ def down(c, volumes=False):
     else:
         c.run(f'{DOCKER_COMPOSE_COMMAND} down', pty=True)
 
-@task
-def up(c, no_search=False, init=False, no_reload=False, scale_build=1):
+@task(help={
+    'search': 'Start search container (default: True)',
+    'init': 'Perform initialization steps (default: False)',
+    'reload': 'Enable automatic process reloading (default: True)',
+    'webpack': 'Start webpack development server (default: False)',
+    'ext-theme-enabled': 'Enable new theme from ext-theme (default: False)',
+})
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme_enabled=False):
     """Start all the docker containers for a Read the Docs instance"""
-    INIT = 'INIT='
-    DOCKER_NO_RELOAD = 'DOCKER_NO_RELOAD='
-    SCALE = f'--scale build={scale_build}'
-    if init:
-        INIT = 'INIT=t'
-    if no_reload:
-        DOCKER_NO_RELOAD = 'DOCKER_NO_RELOAD=t'
+    cmd = []
 
-    if no_search:
-        c.run(f'{INIT} {DOCKER_NO_RELOAD} docker-compose -f {DOCKER_COMPOSE} -f {DOCKER_COMPOSE_OVERRIDE} up {SCALE}', pty=True)
-    else:
-        c.run(f'{INIT} {DOCKER_NO_RELOAD} {DOCKER_COMPOSE_COMMAND} up {SCALE}', pty=True)
+    cmd.append('INIT=t' if init else 'INIT=')
+    cmd.append('DOCKER_NO_RELOAD=t' if not reload else 'DOCKER_NO_RELOAD=')
+
+    cmd.append('docker-compose')
+    cmd.append(f'-f {DOCKER_COMPOSE}')
+    cmd.append(f'-f {DOCKER_COMPOSE_OVERRIDE}')
+
+    if search:
+        cmd.append(f'-f {DOCKER_COMPOSE_SEARCH}')
+    if webpack:
+        # This option implies the theme is enabled automatically
+        ext_theme_enabled = True
+        cmd.append(f'-f {DOCKER_COMPOSE_WEBPACK}')
+        cmd.insert(0, 'RTD_EXT_THEME_DEV_SERVER_ENABLED=t')
+    if ext_theme_enabled:
+        cmd.insert(0, 'RTD_EXT_THEME_ENABLED=t')
+
+    cmd.append('up')
+
+    c.run(' '.join(cmd), pty=True)
+
 
 @task
 def shell(c, running=False, container='web'):


### PR DESCRIPTION
This enables a few pieces needed for local development of the ext-theme
repository:

* Docker can use ext-theme without webpack, built assets are synced to
  storage
* Docker can use ext-theme without webpack, development server starts
  and assets are hot reloaded during development

The `docker.up` tasks was reworked to support the additional
configuration in an easier way. Some of the arguments are flipped,
because invoke automatically gives us command arguments like
`--[no-]search` if you specify `search=True`. The `docker.up` help is
currently:

    Usage: inv[oke] [--core-opts] docker.up [--options] [other tasks here ...]

    Docstring:
      Start all the docker containers for a Read the Docs instance

    Options:
      -e, --ext-theme-enabled   Enable new theme from ext-theme (default: False)
      -i, --init                Perform initialization steps (default: False)
      -r, --[no-]reload         Enable automatic process reloading (default: True)
      -s, --[no-]search         Start search container (default: True)
      -w, --webpack             Start webpack development server (default: False)

Requires #51 