### PR TITLE
Add `running` flag to `docker.manage` task

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -72,9 +72,12 @@ def shell(c, running=False, container='web'):
         c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm {container} /bin/bash', pty=True)
 
 @task
-def manage(c, command):
+def manage(c, command, running=False):
     """Run manage.py with a specific command."""
-    c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web python3 manage.py {command}', pty=True)
+    subcmd = 'run --rm'
+    if running:
+        subcmd = 'exec'
+    c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} web python3 manage.py {command}', pty=True)
 
 @task
 def attach(c, container):


### PR DESCRIPTION
This allows for running things like `collectstatic` from a running
instance:

    inv docker.manage --running collectstatic

Instead of bringing up a new container, an existing container will be
used instead. This allows for the running `web` instance settings to be
reused.