### PR TITLE
Backup PostgreSQL database when running `migrate`

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -81,7 +81,7 @@ def shell(c, running=True, container='web'):
 @task(help={
     'command': 'Command to pass directly to "django-admin" inside the container',
     'running': 'Execute "django-admin" in a running container',
-    'backupdb': 'Backup postgres database when running Django "migrate" command',
+    'backupdb': 'Backup postgres database before running Django "manage" command',
 })
 def manage(c, command, running=True, backupdb=False):
     """Run manage.py with a specific command."""
@@ -89,7 +89,7 @@ def manage(c, command, running=True, backupdb=False):
     if running:
         subcmd = 'exec'
 
-    if command.startswith('migrate') and backupdb:
+    if backupdb:
         c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} database pg_dumpall -c -U docs_user > dump_`date +%d-%m-%Y"_"%H_%M_%S`__`git rev-parse HEAD`.sql', pty=True)
 
     c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} web python3 manage.py {command}', pty=True)

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -81,12 +81,17 @@ def shell(c, running=True, container='web'):
 @task(help={
     'command': 'Command to pass directly to "django-admin" inside the container',
     'running': 'Execute "django-admin" in a running container',
+    'backupdb': 'Backup postgres database when running Django "migrate" command',
 })
-def manage(c, command, running=True):
+def manage(c, command, running=True, backupdb=False):
     """Run manage.py with a specific command."""
     subcmd = 'run --rm'
     if running:
         subcmd = 'exec'
+
+    if command.startswith('migrate') and backupdb:
+        c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} database pg_dumpall -c -U docs_user > dump_`date +%d-%m-%Y"_"%H_%M_%S`__`git rev-parse HEAD`.sql', pty=True)
+
     c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} web python3 manage.py {command}', pty=True)
 
 @task(help={


### PR DESCRIPTION
When calling `inv docker.manage migrate` we can pass `--backupdb` to save an SQL
file with the content of the database before running the migration.

The name of the file uses the current date plus the git commit. This allows us
to go back to the previous state in case it's needed.