### PR TITLE
Use `CTRL-p CTRL-p` to detach an attached container

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -100,7 +100,7 @@ def manage(c, command, running=True, backupdb=False):
 def attach(c, container):
     """Attach a tty to a running container (useful for pdb)."""
     prefix = c['container_prefix'] # readthedocsorg or readthedocs-corporate
-    c.run(f'docker attach --sig-proxy=false {prefix}_{container}_1', pty=True)
+    c.run(f'docker attach --sig-proxy=false --detach-keys="ctrl-p,ctrl-p" {prefix}_{container}_1', pty=True)
 
 @task(help={
     'containers': 'Container(s) to restart (it may restart "nginx" container if required)',


### PR DESCRIPTION
When attaching a container with:

inv docker.attach web

you can now detach it without killing the process with `CTRL-p CTRL-p`. The
default sequence is CTRL-p CTRL-q for containers running with `-i -t` but it
seems that CTRL-q does not get recognized by Invoke for some reason. So, I'm
using CTRL-p CTRL-p for this.

docs.docker.com/engine/reference/commandline/attach
