### PR TITLE
Upgrade postgres to v12.5 (production)

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       readthedocs:
 
   database:
-    image: postgres:11.1
+    image: postgres:12.5
     environment:
       - POSTGRES_USER=docs_user
       - POSTGRES_PASSWORD=docs_pwd


### PR DESCRIPTION
Upgrade postgres database container to match production version, 12.5

To migrate your local data:

##### Dump

```bash
# Before merging this PR
inv docker.up
inv docker.manage --backupdb migrate  # (this should generate a non-empty .sql file)
```

##### Load

```bash
# After merging this PR
docker volume rm community_postgres_backups_data community_postgres_data
inv docker.manage 'up database'
docker cp dump.sql community_database_1:/tmp/dump.sql
inv docker.shell --container database
psql -U docs_user docs_db < /tmp/dump.sql
```


Reference: https://github.com/readthedocs/readthedocs.org/issues/7761