### PR TITLE
Create `test` user on init

### DIFF
--- a/dockerfiles/scripts/createsuperuser.py
+++ b/dockerfiles/scripts/createsuperuser.py
@@ -2,3 +2,6 @@ from django.contrib.auth.models import User
 
 if not User.objects.filter(username='admin').exists():
     User.objects.create_superuser('admin', 'admin@admin.com', 'admin')
+
+if not User.objects.filter(username='test').exists():
+    User.objects.create_superuser('test', 'test@test.com', 'test')


### PR DESCRIPTION
This user is required with the current settings because it's used by builders as
SLUMBER user to hit APIv2 and send commands, request versions, etc.