### PR TITLE
Match Redis to production's version

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     command: ["../../docker/build.sh"]
 
   cache:
-    image: redis:3.2.7
+    image: redis:6.0.5
     networks:
       readthedocs:
 


### PR DESCRIPTION
We are using 6.0.5 in both, .org and .com now.

