### PR TITLE
storage: pin minio version

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       readthedocs:
 
   storage:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     ports:
       - "9000:9000"
     environment:


### PR DESCRIPTION
Latest MinIO version requires some changes to use `--console-address`. Also, the
new version of MinIO will require to update the documentation from our
installation guide.

Let's pin it for now to fix the immediate issue and come back with the proper solution.

Solution taken from @astrojuanlu's comment https://github.com/readthedocs/readthedocs.org/issues/8332#issuecomment-878012472