### PR TITLE
storage: upgrade MinIO to its latest version

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -149,7 +149,7 @@ services:
       readthedocs:
 
   storage:
-    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
+    image: minio/minio:RELEASE.2022-02-24T22-12-01Z.fips
     ports:
       - "9000:9000"
       - "9009:9009"

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -152,11 +152,12 @@ services:
     image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     ports:
       - "9000:9000"
+      - "9009:9009"
     environment:
-      - MINIO_ACCESS_KEY=admin
-      - MINIO_SECRET_KEY=password
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
     volumes:
       - storage_data:/data
     networks:
       readthedocs:
-    command: ["server", "/data"]
+    command: ["server", "--console-address", ":9009", "/data"]


### PR DESCRIPTION
Following #89 to upgrade MinIO to its latest version.

Blocked because it requires updating the documentation from https://docs.readthedocs.io/en/latest/development/install.html with the new steps required since the MinIO Console has changed its look&feel.