### PR TITLE
nginx: disable logs by default

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -24,6 +24,10 @@ services:
       - storage
     volumes:
       - ${PWD}/dockerfiles/nginx:/etc/nginx/conf.d
+    # Disable logs for NGINX by default because they are too noisy and we have
+    # better logs in our application code
+    logging:
+      driver: "none"
 
   proxito:
     volumes:


### PR DESCRIPTION
We have better logs in our application with the usage of structlog and these
access logs from NGINX are too noisy. We can always remove these lines locally
if we are doing a in-depth debug for this.