### PR TITLE
watchmedo: reload build/celery containers properly

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -10,12 +10,11 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="./readthedocs/*.py;./readthedocsinc/*.py" \
+  --patterns="*.py" \
   --ignore-patterns="*.#*.py;*.pyo;*.pyc;*flycheck*.py;*test*;*migrations*;*management/commands*" \
   --ignore-directories \
   --recursive \
   --signal=SIGTERM \
-  --kill-after=5 \
   --interval=5 \
   -- \
   $CMD

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -12,12 +12,11 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="./readthedocs/*.py;./readthedocsinc/*.py" \
+  --patterns="*.py" \
   --ignore-patterns="*.#*.py;*.pyo;*.pyc;*flycheck*.py;*test*;*migrations*;*management/commands*" \
   --ignore-directories \
   --recursive \
   --signal=SIGTERM \
-  --kill-after=5 \
   --interval=5 \
   -- \
   $CMD


### PR DESCRIPTION
* `--kill-after=5` does not work because there is a bug in watchmedo
* simplify pattern to match all Python files (*.py)
* rely on `--ignore-patterns` to avoid extra files