### PR TITLE
Make patterns more specific for watchmedo

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -10,7 +10,7 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="*.py" \
+  --patterns="./readthedocs/*.py;./readthedocsinc/*.py" \
   --ignore-patterns="*.#*.py;*.pyo;*.pyc;*flycheck*.py;*test*;*migrations*;*management/commands*" \
   --ignore-directories \
   --recursive \

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -12,7 +12,7 @@ if [ -n "${DOCKER_NO_RELOAD}" ]; then
 else
   echo "Running Docker with reload"
   watchmedo auto-restart \
-  --patterns="*.py" \
+  --patterns="./readthedocs/*.py;./readthedocsinc/*.py" \
   --ignore-patterns="*.#*.py;*.pyo;*.pyc;*flycheck*.py;*test*;*migrations*;*management/commands*" \
   --ignore-directories \
   --recursive \


### PR DESCRIPTION
reverts some changes from https://github.com/readthedocs/common/pull/106

Builds are getting stuck because celery is being restarted after the clone step when building a project