### PR TITLE
Celery: keep cancelled builds cancelled

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -2,6 +2,11 @@
 
 ../../docker/common.sh
 
+# When a task is revoked, it still needs to be picked up by a worker to "delete it",
+# in the meantime celery will keep those revoked tasks in memory,
+# if you restart celery, that list is lost, and the tasks will be executed after a worker picks it up.
+# We need to save that state in a file so isn't lost.
+# Ref https://docs.celeryq.dev/en/stable/userguide/workers.html#persistent-revokes.
 CELERY_STATE_DIR=/var/run/celery/
 mkdir -p $CELERY_STATE_DIR
 CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l DEBUG --statedb=${CELERY_STATE_DIR}worker.state"

--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -2,7 +2,9 @@
 
 ../../docker/common.sh
 
-CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l DEBUG"
+CELERY_STATE_DIR=/var/run/celery/
+mkdir -p $CELERY_STATE_DIR
+CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l DEBUG --statedb=${CELERY_STATE_DIR}worker.state"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running Docker with no reload"


### PR DESCRIPTION
When a task is revoked, it still needs to be picked up by a worker to "delete it",
in the meantime celery will keep those revoked tasks in memory,
if you restart celery, that list is lost, and the tasks will be executed after a worker picks it up.

Ref https://docs.celeryq.dev/en/stable/userguide/workers.html#persistent-revokes