### PR TITLE
Dependencies: upgrade to be compatible with Python 3.10

### DIFF
--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,3 +1,3 @@
 # requirements file to launch Read the Docs using docker-compose
-invoke==1.3.0
-docker-compose==1.25.0
+invoke==1.7.1
+docker-compose==1.29.2


### PR DESCRIPTION
Without upgrading them, PyYAML fails when compiling it.