### PR TITLE
Development: reduce celery log level from DEBUG to INFO

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       # https://github.com/celery/celery/issues/5761
       - COLUMNS=80
       - DOCKER_NO_RELOAD
+      - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
     stdin_open: true
     tty: true
     networks:
@@ -130,6 +131,7 @@ services:
       # https://github.com/celery/celery/issues/5761
       - COLUMNS=80
       - DOCKER_NO_RELOAD
+      - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -9,7 +9,7 @@
 # Ref https://docs.celeryq.dev/en/stable/userguide/workers.html#persistent-revokes.
 CELERY_STATE_DIR=/var/run/celery/
 mkdir -p $CELERY_STATE_DIR
-CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l DEBUG --statedb=${CELERY_STATE_DIR}worker.state"
+CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l ${CELERY_LOG_LEVEL} --statedb=${CELERY_STATE_DIR}worker.state"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running Docker with no reload"

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -8,7 +8,7 @@ if [ "$SEARCH" != "" ]; then
   ../../docker/wait-for-it.sh search:9200 --timeout=180 --strict
 fi
 
-CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 2 -Q web,web01,reindex,autoscaling -l DEBUG"
+CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 2 -Q web,web01,reindex,autoscaling -l ${CELERY_LOG_LEVEL}"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running Docker with no reload"


### PR DESCRIPTION
Just that. Avoid logging a bunch of unuseful messages and just log INFO ones.
Make usage of an environment variable in case we want to change that from outside.