### PR TITLE
Pin Nginx docker image

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       dockerfile: ${PWD}/dockerfiles/Dockerfile
 
   nginx:
-    image: nginx
+    image: nginx:1.22
     ports:
       - "80:80"
     links:


### PR DESCRIPTION
This was using `latest` on my machine, which was last pulled 2 years ago. Using
an explicit version here for now to avoid this.