### PR TITLE
Gulp eslint: allow es6

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -38,5 +38,9 @@
     "space-unary-ops": "error",
     "spaced-comment": "off",
     "vars-on-top": "off",
+  },
+  "env": {
+    "browser": true,
+    "es6": true
   }
 }


### PR DESCRIPTION
This is so we can use arrow functions, let statements, const, and all other goodies that make JS a little better.