### PR TITLE
Use nodemon for reloading on all server processes

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/proxito.sh:/usr/src/app/docker/proxito.sh
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/common/dockerfiles/nodemon.json:/usr/src/app/checkouts/nodemon.json
     links:
       - storage
       - database
@@ -59,6 +60,7 @@ services:
       - ${PWD}/common/dockerfiles/entrypoints/web.sh:/usr/src/app/docker/web.sh
       - ${PWD}/common/dockerfiles/entrypoints/createbuckets.sh:/usr/src/app/docker/createbuckets.sh
       - ${PWD}/common/dockerfiles/entrypoints/wait-for-it.sh:/usr/src/app/docker/wait-for-it.sh
+      - ${PWD}/common/dockerfiles/nodemon.json:/usr/src/app/checkouts/nodemon.json
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
     links:

--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -12,9 +12,9 @@ mkdir -p $CELERY_STATE_DIR
 CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l ${CELERY_LOG_LEVEL} --statedb=${CELERY_STATE_DIR}worker.state"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
-  echo "Running Docker with no reload"
+  echo "Running process with no reload"
   $CMD
 else
-  echo "Running Docker with reload"
+  echo "Running process with reload"
   nodemon --config ../nodemon.json --exec $CMD
 fi

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -11,9 +11,9 @@ fi
 CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 2 -Q web,web01,reindex,autoscaling -l ${CELERY_LOG_LEVEL}"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
-  echo "Running Docker with no reload"
+  echo "Running process with no reload"
   $CMD
 else
-  echo "Running Docker with reload"
+  echo "Running process with reload"
   nodemon --config ../nodemon.json --exec $CMD
 fi

--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,13 +2,12 @@
 
 ../../docker/common.sh
 
-if [ -n "${DOCKER_NO_RELOAD}" ];
-then
-    RELOAD='--noreload'
-    echo "Running Docker with no reload"
-else
-    RELOAD=''
-    echo "Running Docker with reload"
-fi
+CMD="python3 manage.py runserver 0.0.0.0:8000"
 
-python3 manage.py runserver 0.0.0.0:8000 $RELOAD
+if [ -n "${DOCKER_NO_RELOAD}" ]; then
+  echo "Running process with no reload"
+  $CMD
+else
+  echo "Running process with reload"
+  nodemon --config ../nodemon.json --exec $CMD
+fi

--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="python3 manage.py runserver 0.0.0.0:8000"
+CMD="python3 manage.py runserver --noreload 0.0.0.0:8000"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,12 +2,12 @@
 
 ../../docker/common.sh
 
-CMD="gunicorn readthedocs.wsgi:application -w 2 -b 0.0.0.0:8000 --max-requests=10000"
+CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"
   $CMD
 else
   echo "Running process with reload"
-  nodemon --config ../nodemon.json --exec $CMD
+  nodemon --config ../nodemon.json --exec "${CMD}"
 fi

--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="python3 manage.py runserver --noreload 0.0.0.0:8000"
+CMD="gunicorn readthedocs.wsgi:application -w 2 -b 0.0.0.0:8000 --max-requests=10000"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,7 +13,7 @@ then
     python3 manage.py loaddata test_data
 fi
 
-CMD="python3 manage.py runserver 0.0.0.0:8000"
+CMD="python3 manage.py runserver --noreload 0.0.0.0:8000"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,12 +13,12 @@ then
     python3 manage.py loaddata test_data
 fi
 
-CMD="gunicorn readthedocs.wsgi:application -w 2 -b 0.0.0.0:8000 --max-requests=10000"
+CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"
   $CMD
 else
   echo "Running process with reload"
-  nodemon --config ../nodemon.json --exec $CMD
+  nodemon --config ../nodemon.json --exec "${CMD}"
 fi

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,7 +13,7 @@ then
     python3 manage.py loaddata test_data
 fi
 
-CMD="python3 manage.py runserver --noreload 0.0.0.0:8000"
+CMD="gunicorn readthedocs.wsgi:application -w 2 -b 0.0.0.0:8000 --max-requests=10000"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,13 +13,12 @@ then
     python3 manage.py loaddata test_data
 fi
 
-if [ -n "${DOCKER_NO_RELOAD}" ];
-then
-    RELOAD='--noreload'
-    echo "Running Docker with no reload"
-else
-    RELOAD=''
-    echo "Running Docker with reload"
-fi
+CMD="python3 manage.py runserver 0.0.0.0:8000"
 
-python3 manage.py runserver 0.0.0.0:8000 $RELOAD
+if [ -n "${DOCKER_NO_RELOAD}" ]; then
+  echo "Running process with no reload"
+  $CMD
+else
+  echo "Running process with reload"
+  nodemon --config ../nodemon.json --exec $CMD
+fi

--- a/dockerfiles/nodemon.json
+++ b/dockerfiles/nodemon.json
@@ -3,6 +3,6 @@
     "delay": 2000,
     "ext": "py",
     "watch": ["readthedocs", "readthedocsinc"],
-    "ignore": [".tox/*", ".direnv/*", "user_builds/*", "*/management/commands*", "*migrations/*", "*test*", "*.pyc", "*.pyo"],
+    "ignore": [".tox/*", ".direnv/*", "user_builds/*", "*/management/commands*", "*migrations/*", "*test*", "*.pyc", "*.pyo", "logs/*"],
     "signal": "SIGTERM"
 }

--- a/dockerfiles/nodemon.json
+++ b/dockerfiles/nodemon.json
@@ -1,6 +1,6 @@
 {
-    "verbose": true,
-    "delay": 2500,
+    "verbose": false,
+    "delay": 2000,
     "ext": "py",
     "watch": ["readthedocs", "readthedocsinc"],
     "ignore": [".tox/*", ".direnv/*", "user_builds/*", "*/management/commands*", "*migrations/*", "*test*", "*.pyc", "*.pyo"],


### PR DESCRIPTION
This examples nodemon from the celery entrypoint script to the web and proxito service entrypoint scripts.

The Django runserver --reload option doesn't see to be configurable, and seems to watch a lot of files that are not needed for reloading. I can't tell what exactly is being watched by runserver, but I am getting frequent `too many open files` errors from processes in Docker. Running with --no-reload mostly solves this issue, but requires manually restarting services.

Someone else should spend some time with this, I'm not confident that this will:

1. Fix the issue for others
2. Not cause irreparable damage to your local installation