### PR TITLE
Raise nofile ulimit for web/proxito containers

### DIFF
--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -20,6 +20,10 @@ services:
       - RTD_EXT_THEME_DEV_SERVER_ENABLED
     stdin_open: true
     tty: true
+    ulimits:
+      nofile:
+        soft: 100000
+        hard: 100000
     networks:
       readthedocs:
     command: ["../../docker/webpack.sh"]

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -48,6 +48,10 @@ services:
     # control on STDIN and be able to debug our code with interactive pdb
     stdin_open: true
     tty: true
+    ulimits:
+      nofile:
+        soft: 100000
+        hard: 100000
 
     networks:
       readthedocs:
@@ -79,6 +83,11 @@ services:
       - MINIO_ROOT_PASSWORD=password
     stdin_open: true
     tty: true
+    ulimits:
+      nofile:
+        soft: 100000
+        hard: 100000
+
     networks:
       readthedocs:
     command: ["../../docker/wait-for-it.sh", "database:5432", "--timeout=60", "--strict", "--", "../../docker/web.sh"]


### PR DESCRIPTION
I'm hitting "too many open files" rather consistently (see #160 for a first try at resolving this). I am getting some inconsistent results still, so not sure if this solves the problem or not.

I was just able to start the development env without altering the reload mechanism though, so perhaps this just needs to be bumped up a bit.

I'm also not opposed to changing the reload mechanism too though.