### PR TITLE
Used modern Node for webpack, and us npm ci instead

### DIFF
--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
 
   webpack:
-    image: node:12
+    image: node:16
     working_dir: /usr/src/app/checkouts/ext-theme
     ports:
       - "10001:10001"

--- a/dockerfiles/entrypoints/webpack.sh
+++ b/dockerfiles/entrypoints/webpack.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-npm install
+npm ci
 
 $(npm bin)/webpack-dev-server \
   --mode=development \


### PR DESCRIPTION
This was using a crusty old Node version and was calling `npm install`, so the lock file was being updated and reverted to version 1. This was causing significant spin up time for the docker container.

`npm ci` installs the exact dependencies used in the last build, so we can ensure a CI passing build will match the prod build closely.