### PR TITLE
Development: argument to set logging level

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     environment:
       - DOCKER_NO_RELOAD
       - RTD_PRODUCTION_DOMAIN
+      - RTD_LOGGING_LEVEL
 
     # Allow us to run `docker attach readthedocsorg_proxito_1` and get
     # control on STDIN and be able to debug our code with interactive pdb
@@ -77,6 +78,7 @@ services:
       - RTD_PRODUCTION_DOMAIN
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
+      - RTD_LOGGING_LEVEL
     stdin_open: true
     tty: true
     networks:
@@ -104,6 +106,7 @@ services:
       - DOCKER_NO_RELOAD
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
+      - RTD_LOGGING_LEVEL
     stdin_open: true
     tty: true
     networks:
@@ -123,6 +126,7 @@ services:
       - DOCKER_NO_RELOAD
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
+      - RTD_LOGGING_LEVEL
     stdin_open: true
     tty: true
     networks:
@@ -157,6 +161,7 @@ services:
       - DOCKER_NO_RELOAD
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
+      - RTD_LOGGING_LEVEL
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -43,13 +43,15 @@ def down(c, volumes=False):
     'ext-theme': 'Enable new theme from ext-theme (default: False)',
     'scale-build': 'Add additional build instances (default: 1)',
     'ngrok': 'ngrok domain to serve the application. Example: "17b5-139-47-118-243.ngrok.io"',
+    'log-level': 'Logging level for the Django application (default: INFO)',
 })
-def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, ngrok=""):
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, ngrok="", log_level='INFO'):
     """Start all the docker containers for a Read the Docs instance"""
     cmd = []
 
     cmd.append('INIT=t' if init else 'INIT=')
     cmd.append('DOCKER_NO_RELOAD=t' if not reload else 'DOCKER_NO_RELOAD=')
+    cmd.append(f'RTD_LOGGING_LEVEL={log_level}')
 
     cmd.append('docker-compose')
     cmd.append('--project-directory=.')


### PR DESCRIPTION
It was a little annoying that we had the logging level set to DEBUG since we are flooded wth a lot of messages, even when debugging things.

I set the default logging level to INFO, but added a `log-level=` argument to easily change it in case we want to be more verbose while working locally.