### PR TITLE
Upgrade prospector and use DJANGO_SETTINGS_MODULE for pylint django plugin

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 #       args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
 
 - repo: https://github.com/PyCQA/prospector
-  rev: 1.3.1
+  rev: v1.9.0
   hooks:
     - id: prospector
       args:
@@ -70,7 +70,6 @@ repos:
       additional_dependencies:
         - -r
         - https://raw.githubusercontent.com/readthedocs/readthedocs.org/main/requirements/pip.txt
-        - flake8==3.8.4
 
 - repo: https://github.com/akaihola/darker
   rev: 1.3.2

--- a/prospector.yml
+++ b/prospector.yml
@@ -4,6 +4,8 @@ test-warnings: false
 doc-warnings: true
 
 uses:
+  # We have issues with FKs as strings and failure with astroid
+  # However, leaving out Django causes other linting issues
   - django
   - celery
 
@@ -26,6 +28,8 @@ pep8:
 
 pylint:
   options:
+    # Required for the Django plugin
+    django-settings-module: readthedocs.settings.base
     docstring-min-length: 20
     dummy-variables-rgx: '_$|__$|dummy'
     max-line-length: 100


### PR DESCRIPTION
Am getting hit by a lot of linting issues. Example:

https://app.circleci.com/pipelines/github/ewdurbin/readthedocs.org/9/workflows/088d83c0-1c30-4746-ad80-03f0f0466b7b/jobs/19

I'm trying out this upgrade and then also to lower the strictness level again and will report back.

---

Edit: This PR is essentially just a discussion of linting and its consequences. I think I'd like to advocate that we figure out where to go with our linting tools. Even when they work, having an error about missing punctuation in a docstring seems overkill for where we are with our current codebase :)