### PR TITLE
Remove timeout from web and proxito

### DIFF
--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000"
+CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,7 +13,7 @@ then
     python3 manage.py loaddata test_data
 fi
 
-CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000"
+CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"


### PR DESCRIPTION
The default is 30 seconds, if you enter in a debugging session, the request will be killed, giving no time to debug.