### PR TITLE
Create build bucket

### DIFF
--- a/dockerfiles/entrypoints/createbuckets.sh
+++ b/dockerfiles/entrypoints/createbuckets.sh
@@ -11,5 +11,7 @@ test "${INIT}" || exit 0
 /usr/bin/mc policy set public myminio/media;
 /usr/bin/mc mb myminio/build-tools;
 /usr/bin/mc policy set public myminio/build-tools;
+/usr/bin/mc mb myminio/builds;
+/usr/bin/mc policy set public myminio/builds;
 exit 0;
 


### PR DESCRIPTION
We are running the celery beat tasks now,
one of those tasks is "archive builds",
that task requires the builds bucket.

https://github.com/readthedocs/readthedocs.org/blob/385398e3341a03ce240d1551d028ca89759ccede/readthedocs/settings/docker_compose.py#L183-L183