### PR TITLE
Remove max-line-length from pep8 because it does not get silenced by ignore-patterns

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -19,12 +19,14 @@ ignore-paths:
 ignore-patterns:
   - ^.*/migrations/.*\.py$
   - ^.*/tests/.*\.py$
-  - conftest.py
+  - conftest\.py
 
 pep8:
   full: true
-  options:
-    max-line-length: 100
+# Commented out because it causes errors that aren't silenced by ignore-patterns
+# max-line-length is defined for pylint below.
+#  options:
+#    max-line-length: 100
 
 pylint:
   options:


### PR DESCRIPTION
Referencing "checks" failure here: https://github.com/readthedocs/readthedocs-corporate/pull/1579

Also on a related note: We should minimize prospector or remove it.