### PR TITLE
nodemon: monitor readthedocs.org volume

### DIFF
--- a/dockerfiles/nodemon.json
+++ b/dockerfiles/nodemon.json
@@ -2,7 +2,7 @@
     "verbose": false,
     "delay": 2000,
     "ext": "py",
-    "watch": ["readthedocs", "readthedocsinc"],
+    "watch": ["readthedocs", "readthedocsinc", "../readthedocs.org/readthedocs"],
     "ignore": [".tox/*", ".direnv/*", "user_builds/*", "*/management/commands*", "*migrations/*", "*test*", "*.pyc", "*.pyo", "logs/*"],
     "signal": "SIGTERM"
 }


### PR DESCRIPTION
tested and works :+1: 

Updated: When working with changes to `readthedocs.org` that affect readthedocs-corporate, it's nice to have the mounted volume with `readthedocs.org` also cause reloads. Otherwise, it's only changes to the `readthedocs-corporate` repo that causes reloads.