### PR TITLE
New invoke options: --no-django-debug and --http-proxy (rename)

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       - DOCKER_NO_RELOAD
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
-      - RTD_FORCE_HTTPS
       - RTD_DJANGO_DEBUG
 
     # Allow us to run `docker attach readthedocsorg_proxito_1` and get
@@ -81,7 +80,6 @@ services:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
       - RTD_LOGGING_LEVEL
-      - RTD_FORCE_HTTPS
       - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
@@ -111,7 +109,6 @@ services:
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
-      - RTD_FORCE_HTTPS
       - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
@@ -133,7 +130,6 @@ services:
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
-      - RTD_FORCE_HTTPS
       - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
@@ -170,7 +166,6 @@ services:
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
-      - RTD_FORCE_HTTPS
       - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - DOCKER_NO_RELOAD
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
+      - RTD_FORCE_HTTPS
+      - RTD_DJANGO_DEBUG
 
     # Allow us to run `docker attach readthedocsorg_proxito_1` and get
     # control on STDIN and be able to debug our code with interactive pdb
@@ -79,6 +81,8 @@ services:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
       - RTD_LOGGING_LEVEL
+      - RTD_FORCE_HTTPS
+      - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
     networks:
@@ -107,6 +111,8 @@ services:
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
+      - RTD_FORCE_HTTPS
+      - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
     networks:
@@ -127,6 +133,8 @@ services:
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
+      - RTD_FORCE_HTTPS
+      - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
     networks:
@@ -162,6 +170,8 @@ services:
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
       - RTD_LOGGING_LEVEL
+      - RTD_FORCE_HTTPS
+      - RTD_DJANGO_DEBUG
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -42,10 +42,15 @@ def down(c, volumes=False):
     'webpack': 'Start webpack development server (default: False)',
     'ext-theme': 'Enable new theme from ext-theme (default: False)',
     'scale-build': 'Add additional build instances (default: 1)',
-    'ngrok': 'ngrok domain to serve the application. Example: "17b5-139-47-118-243.ngrok.io"',
+    'http-domain': 'Configure a production domain for HTTP traffic. Subdomains included, '
+                   'example.dev implies *.examples.dev for proxito. Example: '
+                   '"17b5-139-47-118-243.ngrok.io"',
+    'https': 'Forces HTTPS settings that are otherwise undetected when a :443 HTTPS proxy is in '
+             'front of the :80 Nginx container (default: False).',
     'log-level': 'Logging level for the Django application (default: INFO)',
+    'django-debug': 'Sets the DEBUG Django setting (default: True)',
 })
-def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, ngrok="", log_level='INFO'):
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, http_domain="", django_debug=True, https=False, log_level='INFO'):
     """Start all the docker containers for a Read the Docs instance"""
     cmd = []
 
@@ -67,10 +72,18 @@ def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, 
         cmd.insert(0, 'RTD_EXT_THEME_DEV_SERVER_ENABLED=t')
     if ext_theme:
         cmd.insert(0, 'RTD_EXT_THEME_ENABLED=t')
-    if ngrok:
-        cmd.insert(0, f'RTD_PRODUCTION_DOMAIN={ngrok}')
-        cmd.insert(0, f'NGINX_WEB_SERVER_NAME={ngrok}')
-        cmd.insert(0, f'NGINX_PROXITO_SERVER_NAME=*.{ngrok}')
+    if django_debug:
+        cmd.insert(0, 'RTD_DJANGO_DEBUG=t')
+    if http_domain:
+        cmd.insert(0, f'RTD_PRODUCTION_DOMAIN={http_domain}')
+        cmd.insert(0, f'NGINX_WEB_SERVER_NAME={http_domain}')
+        cmd.insert(0, f'NGINX_PROXITO_SERVER_NAME=*.{http_domain}')
+    # This setting was introduced to a new kind of reverse Proxy.
+    # It might be removed and automatically switched on, this depends on how
+    # it works with ngrok, which was previously the only usecase for https
+    # proxies.
+    if https:
+        cmd.insert(0, f'RTD_FORCE_HTTPS=t')
 
     cmd.append('up')
 

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -45,12 +45,10 @@ def down(c, volumes=False):
     'http-domain': 'Configure a production domain for HTTP traffic. Subdomains included, '
                    'example.dev implies *.examples.dev for proxito. Example: '
                    '"17b5-139-47-118-243.ngrok.io"',
-    'https': 'Forces HTTPS settings that are otherwise undetected when a :443 HTTPS proxy is in '
-             'front of the :80 Nginx container (default: False).',
     'log-level': 'Logging level for the Django application (default: INFO)',
     'django-debug': 'Sets the DEBUG Django setting (default: True)',
 })
-def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, http_domain="", django_debug=True, https=False, log_level='INFO'):
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, http_domain="", django_debug=True, log_level='INFO'):
     """Start all the docker containers for a Read the Docs instance"""
     cmd = []
 
@@ -78,12 +76,6 @@ def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, 
         cmd.insert(0, f'RTD_PRODUCTION_DOMAIN={http_domain}')
         cmd.insert(0, f'NGINX_WEB_SERVER_NAME={http_domain}')
         cmd.insert(0, f'NGINX_PROXITO_SERVER_NAME=*.{http_domain}')
-    # This setting was introduced to a new kind of reverse Proxy.
-    # It might be removed and automatically switched on, this depends on how
-    # it works with ngrok, which was previously the only usecase for https
-    # proxies.
-    if https:
-        cmd.insert(0, f'RTD_FORCE_HTTPS=t')
 
     cmd.append('up')
 


### PR DESCRIPTION
Trimmed version of https://github.com/readthedocs/common/pull/176