### PR TITLE
Remove raise-missing-from from pylint warnings

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -46,6 +46,8 @@ pylint:
     - consider-using-f-string
     - logging-format-interpolation
     - too-many-arguments
+    # Super spammy on every PR
+    - raise-missing-from
 
 mccabe:
   run: false


### PR DESCRIPTION
This was super spammy,
and doesn't add any specifi value.
