### PR TITLE
Development: pull down latest Docker images

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -142,7 +142,10 @@ def restart(c, containers):
 def pull(c):
     """Pull all docker images required for build servers."""
     images = [
-        ('ubuntu-22.04-2023.03.09', 'ubuntu-20.04-2022.02.16'),
+        # TODO: remove Ubuntu 20.04 once we start cloning with Ubuntu 22.04
+        # https://github.com/readthedocs/readthedocs.org/blob/c166379bfe48d6757920848bbd49286057b945c1/readthedocs/doc_builder/director.py#L138-L140
+        ('ubuntu-20.04-2022.02.16', 'ubuntu-20.04'),
+        ('ubuntu-22.04-2023.03.09', 'ubuntu-22.04'),
     ]
     for image, tag in images:
         c.run(f'docker pull readthedocs/build:{image}', pty=True)

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -138,21 +138,12 @@ def restart(c, containers):
             c.run(f'{DOCKER_COMPOSE_COMMAND} restart nginx', pty=True)
             break
 
-@task(help={
-    'only_required': 'Only pull the required image (used by default for clonning). Use it if you don\'t need all images (default: False)',
-})
-def pull(c, only_required=False):
+@task()
+def pull(c):
     """Pull all docker images required for build servers."""
     images = [
-        ('ubuntu-20.04-2022.02.16', 'ubuntu-20.04'),
+        ('ubuntu-22.04-2023.03.09', 'ubuntu-20.04-2022.02.16'),
     ]
-    if not only_required:
-        images.extend([
-            ('6.0', 'stable'),
-            ('7.0', 'latest'),
-            ('8.0', 'testing'),
-            ('ubuntu-22.04-2022.03.15', 'ubuntu-22.04'),
-        ])
     for image, tag in images:
         c.run(f'docker pull readthedocs/build:{image}', pty=True)
         c.run(f'docker tag readthedocs/build:{image} readthedocs/build:{tag}', pty=True)


### PR DESCRIPTION
We are not using `latest`, `stable` and `testing` anymore. We are only using Ubuntu images. Download only those 2.