### PR TITLE
Invoke: `docker.compilebuildtool` command

### DIFF
--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,3 +1,4 @@
 # requirements file to launch Read the Docs using docker-compose
 invoke==1.7.1
 docker-compose==1.29.2
+awscli==1.29.7

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -198,3 +198,75 @@ def translations(c, action):
         c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && python3 ../manage.py makemessages --locale en"', pty=True)
         c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web ./tx --token {transifex_token} push --source', pty=True)
         c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && python3 ../manage.py compilemessages --locale en"', pty=True)
+
+
+@task(help={
+    'tool': 'build.tool to compile (python, nodejs, rust, golang)',
+    'version': 'specific version for the tool',
+    'os': 'ubuntu-20.04 or ubuntu-22.04 (default)',
+})
+def compilebuildtool(c, tool, version, os='ubuntu-22.04'):
+    """Compile a ``build.tools`` to be able to use that tool/version from a build in a quick way."""
+    DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
+    # Copy&paste from ``readthedocs/settings/base.py``
+    # We cannot import it directly because it has a bunch of depedencies that are not installed.
+    # I tried using ``ast``, but it was too complex
+    RTD_DOCKER_BUILD_SETTINGS = {
+        # Mapping of build.os options to docker image.
+        'os': {
+            'ubuntu-20.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04',
+            'ubuntu-22.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-22.04',
+        },
+        # Mapping of build.tools options to specific versions.
+        'tools': {
+            'python': {
+                '2.7': '2.7.18',
+                '3.6': '3.6.15',
+                '3.7': '3.7.17',
+                '3.8': '3.8.17',
+                '3.9': '3.9.17',
+                '3.10': '3.10.12',
+                '3.11': '3.11.4',
+                'miniconda3-4.7': 'miniconda3-4.7.12',
+                'mambaforge-4.10': 'mambaforge-4.10.3-10',
+            },
+            'nodejs': {
+                '14': '14.20.1',
+                '16': '16.18.1',
+                '18': '18.16.1',  # LTS
+                '19': '19.0.1',
+                '20': '20.3.1',
+            },
+            'rust': {
+                '1.55': '1.55.0',
+                '1.61': '1.61.0',
+                '1.64': '1.64.0',
+                '1.70': '1.70.0',
+            },
+            'golang': {
+                '1.17': '1.17.13',
+                '1.18': '1.18.10',
+                '1.19': '1.19.10',
+                '1.20': '1.20.5',
+            },
+        },
+    }
+
+    oss = RTD_DOCKER_BUILD_SETTINGS['os'].keys()
+    if os not in oss:
+        print(f'Invalid os. You must specify one of {", ".join(oss)}')
+        sys.exit(1)
+
+    tools = RTD_DOCKER_BUILD_SETTINGS['tools'].keys()
+    if tool not in tools:
+        print(f'Invalid tool. You must specify one of {", ".join(tools)}')
+        sys.exit(1)
+
+    versions = RTD_DOCKER_BUILD_SETTINGS['tools'][tool].keys()
+    if version not in versions:
+        print(f'Invalid version for the specified tool. You must specify one of {", ".join(versions)}')
+        sys.exit(1)
+
+    final_version = RTD_DOCKER_BUILD_SETTINGS['tools'][tool][version]
+
+    c.run(f'OS={os} ./scripts/compile_version_upload_s3.sh {tool} {final_version}')

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -209,19 +209,19 @@ def compilebuildtool(c, tool, version, os='ubuntu-22.04'):
     """Compile a ``build.tools`` to be able to use that tool/version from a build in a quick way."""
     from readthedocs.builds._docker import RTD_DOCKER_BUILD_SETTINGS
 
-    oss = RTD_DOCKER_BUILD_SETTINGS['os'].keys()
-    if os not in oss:
-        print(f'Invalid os. You must specify one of {", ".join(oss)}')
+    valid_oss = RTD_DOCKER_BUILD_SETTINGS['os'].keys()
+    if os not in valid_oss:
+        print(f'Invalid os. You must specify one of {", ".join(valid_oss)}')
         sys.exit(1)
 
-    tools = RTD_DOCKER_BUILD_SETTINGS['tools'].keys()
-    if tool not in tools:
-        print(f'Invalid tool. You must specify one of {", ".join(tools)}')
+    valid_tools = RTD_DOCKER_BUILD_SETTINGS['tools'].keys()
+    if tool not in valid_tools:
+        print(f'Invalid tool. You must specify one of {", ".join(valid_tools)}')
         sys.exit(1)
 
-    versions = RTD_DOCKER_BUILD_SETTINGS['tools'][tool].keys()
-    if version not in versions:
-        print(f'Invalid version for the specified tool. You must specify one of {", ".join(versions)}')
+    valid_versions = RTD_DOCKER_BUILD_SETTINGS['tools'][tool].keys()
+    if version not in valid_versions:
+        print(f'Invalid version for the specified tool. You must specify one of {", ".join(valid_versions)}')
         sys.exit(1)
 
     final_version = RTD_DOCKER_BUILD_SETTINGS['tools'][tool][version]

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -207,7 +207,7 @@ def translations(c, action):
 })
 def compilebuildtool(c, tool, version, os='ubuntu-22.04'):
     """Compile a ``build.tools`` to be able to use that tool/version from a build in a quick way."""
-    from readthedocs.builds._docker import RTD_DOCKER_BUILD_SETTINGS
+    from readthedocs.builds.constants_docker import RTD_DOCKER_BUILD_SETTINGS
 
     valid_oss = RTD_DOCKER_BUILD_SETTINGS['os'].keys()
     if os not in valid_oss:

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -207,50 +207,7 @@ def translations(c, action):
 })
 def compilebuildtool(c, tool, version, os='ubuntu-22.04'):
     """Compile a ``build.tools`` to be able to use that tool/version from a build in a quick way."""
-    DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
-    # Copy&paste from ``readthedocs/settings/base.py``
-    # We cannot import it directly because it has a bunch of depedencies that are not installed.
-    # I tried using ``ast``, but it was too complex
-    RTD_DOCKER_BUILD_SETTINGS = {
-        # Mapping of build.os options to docker image.
-        'os': {
-            'ubuntu-20.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04',
-            'ubuntu-22.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-22.04',
-        },
-        # Mapping of build.tools options to specific versions.
-        'tools': {
-            'python': {
-                '2.7': '2.7.18',
-                '3.6': '3.6.15',
-                '3.7': '3.7.17',
-                '3.8': '3.8.17',
-                '3.9': '3.9.17',
-                '3.10': '3.10.12',
-                '3.11': '3.11.4',
-                'miniconda3-4.7': 'miniconda3-4.7.12',
-                'mambaforge-4.10': 'mambaforge-4.10.3-10',
-            },
-            'nodejs': {
-                '14': '14.20.1',
-                '16': '16.18.1',
-                '18': '18.16.1',  # LTS
-                '19': '19.0.1',
-                '20': '20.3.1',
-            },
-            'rust': {
-                '1.55': '1.55.0',
-                '1.61': '1.61.0',
-                '1.64': '1.64.0',
-                '1.70': '1.70.0',
-            },
-            'golang': {
-                '1.17': '1.17.13',
-                '1.18': '1.18.10',
-                '1.19': '1.19.10',
-                '1.20': '1.20.5',
-            },
-        },
-    }
+    from readthedocs.builds._docker import RTD_DOCKER_BUILD_SETTINGS
 
     oss = RTD_DOCKER_BUILD_SETTINGS['os'].keys()
     if os not in oss:

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -138,21 +138,15 @@ def restart(c, containers):
             c.run(f'{DOCKER_COMPOSE_COMMAND} restart nginx', pty=True)
             break
 
-@task(help={
-    'only_required': 'Only pull the required image (used by default for clonning). Use it if you don\'t need all images (default: False)',
-})
-def pull(c, only_required=False):
+@task()
+def pull(c):
     """Pull all docker images required for build servers."""
     images = [
+        # TODO: remove Ubuntu 20.04 once we start cloning with Ubuntu 22.04
+        # https://github.com/readthedocs/readthedocs.org/blob/c166379bfe48d6757920848bbd49286057b945c1/readthedocs/doc_builder/director.py#L138-L140
         ('ubuntu-20.04-2022.02.16', 'ubuntu-20.04'),
+        ('ubuntu-22.04-2023.03.09', 'ubuntu-22.04'),
     ]
-    if not only_required:
-        images.extend([
-            ('6.0', 'stable'),
-            ('7.0', 'latest'),
-            ('8.0', 'testing'),
-            ('ubuntu-22.04-2022.03.15', 'ubuntu-22.04'),
-        ])
     for image, tag in images:
         c.run(f'docker pull readthedocs/build:{image}', pty=True)
         c.run(f'docker tag readthedocs/build:{image} readthedocs/build:{tag}', pty=True)


### PR DESCRIPTION
Simplify how we pre-compile `build.tools` on development.