### PR TITLE
Development: do not install docker-compose

### DIFF
--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,3 +1,2 @@
 # requirements file to launch Read the Docs using docker-compose
 invoke==1.7.1
-docker-compose==1.29.2


### PR DESCRIPTION
Docker Copmose V1 is deprecated and should not be used anymore. The new version, V2, is written in Go and it can't be installed with `pip`.