### PR TITLE
Lint: we are ready to use Black now

### DIFF
--- a/isort.cfg
+++ b/isort.cfg
@@ -1,15 +1,9 @@
-# TODO: Use `profile = "black"` once we are fully migrated to Black.
-# Otherwise, isort and black will interfer together.
-# Also, make sure to run isort from pre-commit when removing darker.
-
+# NOTE: we are not using `profile=black` because our configuration differs a little from Black
+# and we don't want to re-style all the imports again.
 [settings]
 line_length=88
 indent=4
-
-# TODO: I think we want ``4 (Hanging Grid)`` but given the problems we
-# are having with yapf and add-trailing-comma; we are force to use 3.
 multi_line_output=3
-
 lines_after_imports=-1
 combine_as_imports=False
 force_adds=False

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -70,6 +70,13 @@ repos:
             readthedocs/rtd_tests/files/conf.py|
         )$
 
+# NOTE: run `isort` after `black` to keep the format of isort finally
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      name: isort (python)
+
 - repo: https://github.com/asottile/blacken-docs
   rev: 1.13.0
   hooks:

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       args: ['--fix=lf']
 
 - repo: https://github.com/PyCQA/autoflake
-  rev: v2.1.1
+  rev: v2.2.0
   hooks:
     - id: autoflake
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
@@ -51,7 +51,7 @@ repos:
 #       args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
 
 - repo: https://github.com/adamchainz/django-upgrade
-  rev: "1.14.0"
+  rev: "1.14.1"
   hooks:
   - id: django-upgrade
     args: [--target-version, "4.2"]
@@ -78,7 +78,7 @@ repos:
       name: isort (python)
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.13.0
+  rev: 1.16.0
   hooks:
     - id: blacken-docs
       additional_dependencies: [black==23.7.0]

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -56,16 +56,15 @@ repos:
   - id: django-upgrade
     args: [--target-version, "4.2"]
 
-- repo: https://github.com/akaihola/darker
-  rev: 1.7.1
+- repo: https://github.com/psf/black
+  rev: 23.7.0
   hooks:
-    - id: darker
-      # TODO: find a way to pass `--check` only when running via `tox -e
-      # pre-commit`
-      args: ['--isort']
-      additional_dependencies:
-        - isort==5.12.0
-        - black==23.7.0
+    - id: black
+      # It is recommended to specify the latest version of Python
+      # supported by your project here, or alternatively use
+      # pre-commit's default_language_version, see
+      # https://pre-commit.com/#top_level-default_language_version
+      language_version: python3.10
       exclude: |
         (?x)^(
             readthedocs/rtd_tests/files/conf.py|


### PR DESCRIPTION
We already ran black on all the codebase, so we should be ready to run black instead of darker.