### PR TITLE
Allow passing in Stripe configuration from the host

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - RTD_DJANGO_DEBUG
       - RTD_STRIPE_SECRET
       - RTD_STRIPE_PUBLISHABLE
+      - RTD_DJSTRIPE_WEBHOOK_SECRET
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       - MINIO_ROOT_PASSWORD=password
       - RTD_LOGGING_LEVEL
       - RTD_DJANGO_DEBUG
+      - RTD_STRIPE_SECRET
+      - RTD_STRIPE_PUBLISHABLE
     stdin_open: true
     tty: true
     networks:


### PR DESCRIPTION
This is to avoid stashing/unstashing settings and to push this towards a local `.envrc` file instead, where the secrets can be encrypted. Keeping unencrypted settings in stash history is a pattern to avoid.