### PR TITLE
Development: use `wrangler` locally (Docker container)

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       "--name=force-addons",
       "--latest",
       "--log-level=info",
-      "--host=wrangler:8080",
+      "--host=proxito:8080",
       "--ip=0.0.0.0",
       "--port=8000",
     ]

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -22,12 +22,35 @@ services:
       - web
       - proxito
       - storage
+      - wrangler
+    networks:
+      readthedocs:
     volumes:
       - ${PWD}/dockerfiles/nginx:/etc/nginx/templates
     # Disable logs for NGINX by default because they are too noisy and we have
     # better logs in our application code
     logging:
       driver: "none"
+
+  wrangler:
+    build:
+      context: ${PWD}
+      dockerfile: ${PWD}/dockerfiles/Dockerfile.wrangler
+    volumes:
+      - ${PWD}/../readthedocs-ops/terraform/prod/cloudflare/workers/force-readthedocs-addons.js:/usr/src/app/docker/force-readthedocs-addons.js
+    networks:
+      readthedocs:
+    command: [
+      "wrangler",
+      "dev",
+      "/usr/src/app/docker/force-readthedocs-addons.js",
+      "--name=force-addons",
+      "--latest",
+      "--log-level=info",
+      "--host=nginx:8080",
+      "--ip=0.0.0.0",
+      "--port=8000",
+    ]
 
   proxito:
     volumes:

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       "--name=force-addons",
       "--latest",
       "--log-level=error",
-      "--host=nginx:8080",
+      "--host=nginx:8080",  # El Proxito on NGINX configuration
       "--ip=0.0.0.0",
       "--port=8000",
     ]

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       "--name=force-addons",
       "--latest",
       "--log-level=info",
-      "--host=nginx:8080",
+      "--host=wrangler:8080",
       "--ip=0.0.0.0",
       "--port=8000",
     ]

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - wrangler
     networks:
       readthedocs:
+    environment:
+      - NGINX_ADDONS_GITHUB_TAG=0.9.5
     volumes:
       - ${PWD}/dockerfiles/nginx:/etc/nginx/templates
     # Disable logs for NGINX by default because they are too noisy and we have

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       context: ${PWD}
       dockerfile: ${PWD}/dockerfiles/Dockerfile.wrangler
     volumes:
-      - ${PWD}/../readthedocs-ops/terraform/prod/cloudflare/workers/force-readthedocs-addons.js:/usr/src/app/docker/force-readthedocs-addons.js
+      - ${PWD}/dockerfiles/force-readthedocs-addons.js:/usr/src/app/docker/force-readthedocs-addons.js
     networks:
       readthedocs:
     command: [
@@ -46,8 +46,8 @@ services:
       "/usr/src/app/docker/force-readthedocs-addons.js",
       "--name=force-addons",
       "--latest",
-      "--log-level=info",
-      "--host=proxito:8080",
+      "--log-level=error",
+      "--host=nginx:8080",
       "--ip=0.0.0.0",
       "--port=8000",
     ]


### PR DESCRIPTION
Start a new `wrangler` Docker container for the development worker/server process that executes the JS file.

Related https://github.com/readthedocs/addons/issues/217