### PR TITLE
Elasticsearch: disable HTTPS

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -26,6 +26,8 @@ services:
       - cluster.info.update.interval=30m
       - "ES_JAVA_OPTS=-Xms128m -Xmx128m"
       - ELASTIC_PASSWORD=password
+      # Disable HTTPS on development.
+      - xpack.security.transport.ssl.enabled=false
     ports:
       - "9200:9200"
     links:


### PR DESCRIPTION
Instead of disabling the whole security package (https://github.com/readthedocs/common/commit/151504fbc8a2b399a6277c92bf549f3168c026b1) we just need to disable HTTPS for Elasticsearch.

I just hit this problem in a fresh environment.