### PR TITLE
Remove pydocstyle check that Black doesn't use

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -75,6 +75,7 @@ pep257:
     - D212  # Multi-line docstring summary should start at the first line
 
     # pydocstyle
+    - D203  # 1 blank line required before class docstring (found 0)
     - D403  # First word of the first line should be properly capitalized ('Github', not 'GitHub')
     - D406  # Section name should end with a newline ('Examples', not 'Examples::')
     - D407  # Missing dashed underline after section ('Examples')


### PR DESCRIPTION
I'm assuming we shouldn't have checks that conflict with Black,
so removing this.
