### PR TITLE
docker.up: Fix --no-django-debug behavior and introduce --detach

### DIFF
--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -47,8 +47,9 @@ def down(c, volumes=False):
                    '"17b5-139-47-118-243.ngrok.io"',
     'log-level': 'Logging level for the Django application (default: INFO)',
     'django-debug': 'Sets the DEBUG Django setting (default: True)',
+    'detach': 'Start containers in background (default: False)',
 })
-def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, http_domain="", django_debug=True, log_level='INFO'):
+def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, scale_build=1, http_domain="", django_debug=True, log_level='INFO', detach=False):
     """Start all the docker containers for a Read the Docs instance"""
     cmd = []
 
@@ -77,6 +78,9 @@ def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, 
         cmd.insert(0, f'NGINX_PROXITO_SERVER_NAME=*.{http_domain}')
 
     cmd.append('up')
+
+    if detach:
+        cmd.append('--detach')
 
     cmd.append(f'--scale build={scale_build}')
 


### PR DESCRIPTION
I'd like to propose a couple of small tweaks to `inv docker.up`

RTD_DJANGO_DEBUG has a default value of True, so ensure that an empty variable is passed to docker compose when --no-django-debug is passed to inv docker.up.

docker.up: Introduce the --detach parameter. This makes it simple to start the application in detached/daemon
mode without requiring a terminal to output to.