### PR TITLE
Dev: Upgrade to pyinvoke 2.2.0

### DIFF
--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,3 +1,3 @@
 # requirements file to launch Read the Docs using docker-compose
-invoke==1.7.1
+invoke==2.2.0
 awscli==1.29.7


### PR DESCRIPTION
pyinvoke 1.7.1 fails with Python 3.11 due to changes to inspect.getargspec in the standard library. This has been fixed in 2.2.0

A smoke test of `inv docker.up` and `inv docker.down` are successful and the changelog (https://www.pyinvoke.org/changelog.html) doesn't mention any breaking changes other than the Python version. 2.2.0 supports all currently maintained versions of Python.