### PR TITLE
Development: reduce gunicorn loglevel

### DIFF
--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
+CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --log-level=CRITICAL --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,7 +13,7 @@ then
     python3 manage.py loaddata test_data
 fi
 
-CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
+CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --log-level=CRITICAL --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"


### PR DESCRIPTION
Remove a bunch of these following lines when modifying a file.

```
proxito_1      | [2024-03-06 15:32:58 +0000] [22] [ERROR] Worker (pid:23) was sent SIGTERM!
proxito_1      | [2024-03-06 15:32:58 +0000] [22] [ERROR] Worker (pid:24) was sent SIGTERM!
```