### PR TITLE
Search: protect ourselves from executing long queries

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -24,6 +24,7 @@ services:
       - node.name=search
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.info.update.interval=30m
+      - search.default_search_timeout=15s
       - "ES_JAVA_OPTS=-Xms128m -Xmx128m"
       - ELASTIC_PASSWORD=password
       # Disable HTTPS on development.


### PR DESCRIPTION
This is similar to what we are doing in PostgreSQL to avoid running long queries and degrading the service.

Related https://github.com/readthedocs/addons/issues/84