### PR TITLE
Dev: Pass http-domain to RTD_PUBLIC_DOMAIN too

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -68,6 +68,7 @@ services:
     environment:
       - DOCKER_NO_RELOAD
       - RTD_PRODUCTION_DOMAIN
+      - RTD_PUBLIC_DOMAIN
       - RTD_LOGGING_LEVEL
       - RTD_DJANGO_DEBUG
 
@@ -102,6 +103,7 @@ services:
       - RTD_EXT_THEME_ENABLED
       - RTD_EXT_THEME_DEV_SERVER_ENABLED
       - RTD_PRODUCTION_DOMAIN
+      - RTD_PUBLIC_DOMAIN
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
       - RTD_LOGGING_LEVEL
@@ -136,6 +138,7 @@ services:
       - DOCKER_NO_RELOAD
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
+      - RTD_PUBLIC_DOMAIN
       - RTD_LOGGING_LEVEL
       - RTD_DJANGO_DEBUG
     stdin_open: true
@@ -157,6 +160,7 @@ services:
       - DOCKER_NO_RELOAD
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
+      - RTD_PUBLIC_DOMAIN
       - RTD_LOGGING_LEVEL
       - RTD_DJANGO_DEBUG
     stdin_open: true
@@ -193,6 +197,7 @@ services:
       - DOCKER_NO_RELOAD
       - CELERY_LOG_LEVEL=${CELERY_LOG_LEVEL:-INFO}
       - RTD_PRODUCTION_DOMAIN
+      - RTD_PUBLIC_DOMAIN
       - RTD_LOGGING_LEVEL
       - RTD_DJANGO_DEBUG
     stdin_open: true

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -74,6 +74,7 @@ def up(c, search=True, init=False, reload=True, webpack=False, ext_theme=False, 
         cmd.insert(0, 'RTD_DJANGO_DEBUG=t')
     if http_domain:
         cmd.insert(0, f'RTD_PRODUCTION_DOMAIN={http_domain}')
+        cmd.insert(0, f'RTD_PUBLIC_DOMAIN={http_domain}')
         cmd.insert(0, f'NGINX_WEB_SERVER_NAME={http_domain}')
         cmd.insert(0, f'NGINX_PROXITO_SERVER_NAME=*.{http_domain}')
 


### PR DESCRIPTION
acc68e51 added the ability to customize RTD_PRODUCTION_DOMAIN using the --http-domain argument to docker.up

The Docker Compose settings also allows RTD_PUBLIC_DOMAIN to be configured using an env var but this appears to be unused. Pass http-domain to RTD_PUBLIC_DOMAIN too so that the generated docs can be tested on a custom domain too.

Pass RTD_PUBLIC_DOMAIN to the containers wherever RTD_PRODUCTION_DOMAIN is used.