### PR TITLE
Update docker compose files

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -1,6 +1,5 @@
 # docker-compose-search.yml starts "search" service and override some
 # services to link them so they can use the "search" as well.
-version: '3'
 
 volumes:
   search_data:

--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -1,6 +1,5 @@
 # docker-compose-webpack.yml starts Webpack dev server for hot reload of built
 # static assets.
-version: '3'
 
 services:
 

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 volumes:
   build-user-builds:
   storage_data:
@@ -217,7 +215,7 @@ services:
       readthedocs:
 
   database:
-    image: postgres:12.5
+    image: postgres:12.17
     environment:
       - POSTGRES_USER=docs_user
       - POSTGRES_PASSWORD=docs_pwd


### PR DESCRIPTION
- Version is no longer needed (https://github.com/docker/compose/issues/11628)
- The version of postgres doesn't work with the latest version of docker for some reason, puling that image results in `layers from manifest don't match image configuration`. Also, 12.17 is what we use in production.