### PR TITLE
Cloudflare: skip running the worker if >1Mb

### DIFF
--- a/dockerfiles/force-readthedocs-addons.js
+++ b/dockerfiles/force-readthedocs-addons.js
@@ -81,7 +81,7 @@ async function handleRequest(request) {
   // the user will see the page rendering properly, but without any of the addons injected
   // this is an intermediate workaround/solution for
   // https://github.com/readthedocs/readthedocs-ops/issues/1513
-  if (contentLength && contentLength >= 1000000) {
+  if (contentLength && parseInt(contentLength) >= 1000000) {
     console.log("Skipping running Cloudflare Worker because the response's body is bigger than 1Mb.");
     return originalResponse;
   }


### PR DESCRIPTION
Don't execute our worker if the file size is bigger than 1Mb. This is to avoid a "Parser error: The memory limit has been exceeded." for now, but we should be able to find a better solution that also works for these big files.

Closes https://github.com/readthedocs/readthedocs-ops/issues/1513