### PR TITLE
Fix wrangler docker again

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -42,8 +42,6 @@ services:
       readthedocs:
     working_dir: /usr/src/app/packages/addons-inject/
     command: [
-      "node_modules/.bin/wrangler",
-      "dev",
       "--log-level=info",
       "--host=nginx:8080",  # El Proxito on NGINX configuration
       "--ip=0.0.0.0",

--- a/packages/addons-inject/Dockerfile
+++ b/packages/addons-inject/Dockerfile
@@ -4,4 +4,4 @@ COPY index.js /usr/src/app/packages/addons-inject/
 COPY wrangler.toml /usr/src/app/packages/addons-inject/
 WORKDIR /usr/src/app/packages/addons-inject/
 RUN npm install --omit dev
-CMD ["node_modules/.bin/wrangler", "dev"]
+ENTRYPOINT ["node_modules/.bin/wrangler", "dev"]


### PR DESCRIPTION
At some point this pattern got changed and I noticed "invalid arguments" error from Wrangler on starting the container. Swithcing this to entrypoint and only passing in arguments from the docker compose configuration to avoid this all.