### PR TITLE
Install package globally instead

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       readthedocs:
     working_dir: /usr/src/app/packages/addons-inject/
     command: [
+      "wrangler",
+      "dev",
       "--log-level=info",
       "--host=nginx:8080",  # El Proxito on NGINX configuration
       "--ip=0.0.0.0",

--- a/packages/addons-inject/Dockerfile
+++ b/packages/addons-inject/Dockerfile
@@ -4,4 +4,5 @@ COPY index.js /usr/src/app/packages/addons-inject/
 COPY wrangler.toml /usr/src/app/packages/addons-inject/
 WORKDIR /usr/src/app/packages/addons-inject/
 RUN npm install -g --install-links --omit dev
-ENTRYPOINT ["/usr/local/lib/node_modules/@readthedocs/addons-inject/node_modules/.bin/wrangler", "dev"]
+ENV PATH="$PATH:/usr/local/lib/node_modules/@readthedocs/addons-inject/node_modules/.bin"
+CMD ["wrangler", "dev"]

--- a/packages/addons-inject/Dockerfile
+++ b/packages/addons-inject/Dockerfile
@@ -3,5 +3,5 @@ COPY package.json /usr/src/app/packages/addons-inject/
 COPY index.js /usr/src/app/packages/addons-inject/
 COPY wrangler.toml /usr/src/app/packages/addons-inject/
 WORKDIR /usr/src/app/packages/addons-inject/
-RUN npm install --omit dev
-ENTRYPOINT ["node_modules/.bin/wrangler", "dev"]
+RUN npm install -g --install-links --omit dev
+ENTRYPOINT ["/usr/local/lib/node_modules/@readthedocs/addons-inject/node_modules/.bin/wrangler", "dev"]


### PR DESCRIPTION
I finally realized why I am getting different results here. It's because I was already doing local development on the package locally, so when I mounted my path, which included a `node_modules` path, everything kept working in the container.

If you do not have this path locally, when the docker compose container starts, your local path overlays the image's `node_modules` (and all of the installed packages there).

Instead, we can avoid this entirely by instead installing the package globally, outside the package path.