### PR TITLE
Spin a Docker container for addons

### DIFF
--- a/dockerfiles/Dockerfile.addons
+++ b/dockerfiles/Dockerfile.addons
@@ -1,0 +1,4 @@
+FROM node:18.15
+COPY package.json /usr/src/app/addons/
+WORKDIR /usr/src/app/addons/
+RUN npm install

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -23,8 +23,6 @@ services:
       - wrangler
     networks:
       readthedocs:
-    environment:
-      - NGINX_ADDONS_GITHUB_TAG=0.21.0
     volumes:
       - ${PWD}/dockerfiles/nginx:/etc/nginx/templates
     # Disable logs for NGINX by default because they are too noisy and we have
@@ -46,6 +44,24 @@ services:
       "--host=nginx:8080",  # El Proxito on NGINX configuration
       "--ip=0.0.0.0",
       "--port=8000",
+    ]
+
+  addons:
+    build:
+      context: ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}
+      dockerfile: ${PWD}/common/dockerfiles/Dockerfile.addons
+    networks:
+      readthedocs:
+    volumes:
+      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/src/:/usr/src/app/addons/src/
+      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/webpack.config.js/:/usr/src/app/addons/webpack.config.js
+    working_dir: /usr/src/app/addons/
+    ports:
+      - "8000:8000"
+    command: [
+      "npm",
+      "run",
+      "dev",
     ]
 
   proxito:

--- a/packages/addons-inject/index.js
+++ b/packages/addons-inject/index.js
@@ -18,7 +18,7 @@
 export class AddonsConstants {
   // Add "readthedocs-addons.js" inside the "<head>"
   static scriptAddons =
-  '<script async type="text/javascript" src="http://localhost:8000/readthedocs-addons.js"></script>';
+    '<script async type="text/javascript" src="/_/static/javascript/readthedocs-addons.js"></script>';
 
   // Selectors we want to remove
   // https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/#selectors

--- a/packages/addons-inject/index.js
+++ b/packages/addons-inject/index.js
@@ -18,7 +18,7 @@
 export class AddonsConstants {
   // Add "readthedocs-addons.js" inside the "<head>"
   static scriptAddons =
-    '<script async type="text/javascript" src="/_/static/javascript/readthedocs-addons.js"></script>';
+  '<script async type="text/javascript" src="http://localhost:8000/readthedocs-addons.js"></script>';
 
   // Selectors we want to remove
   // https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/#selectors


### PR DESCRIPTION
With this, running `inv docker.up` will automatically spin up a new container for addons. You can edit the code from your `../addons/` repository and get feedback immediately without reloading.