### PR TITLE
Follow current pattern for wrangler container

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -37,11 +37,14 @@ services:
       context: ${PWD}/common/packages/addons-inject/
       dockerfile: ${PWD}/common/packages/addons-inject/Dockerfile
     volumes:
-      - ${PWD}/common/packages/addons-inject/:/usr/src/app/packages/addons-inject/
+      - ${PWD}/common/packages/addons-inject/index.js:/usr/src/app/packages/addons-inject/index.js
+      - ${PWD}/common/packages/addons-inject/wrangler.toml:/usr/src/app/packages/addons-inject/wrangler.toml
     networks:
       readthedocs:
     working_dir: /usr/src/app/packages/addons-inject/
     command: [
+      "node_modules/.bin/wrangler",
+      "dev",
       "--log-level=info",
       "--host=nginx:8080",  # El Proxito on NGINX configuration
       "--ip=0.0.0.0",

--- a/packages/addons-inject/Dockerfile
+++ b/packages/addons-inject/Dockerfile
@@ -1,7 +1,4 @@
 FROM node:18.15
 COPY package.json /usr/src/app/packages/addons-inject/
-COPY index.js /usr/src/app/packages/addons-inject/
-COPY wrangler.toml /usr/src/app/packages/addons-inject/
 WORKDIR /usr/src/app/packages/addons-inject/
 RUN npm install --omit dev
-ENTRYPOINT ["node_modules/.bin/wrangler", "dev"]


### PR DESCRIPTION
I update the wrangler Docker configuration to follow the pattern we already have
for other containers. It mounts only the files that are needed to work and
nothing else.

This is done as an alterntive to #232
that should work for everybody.