### PR TITLE
Docker: standardize Docker compose configuration

### DIFF
--- a/dockerfiles/Dockerfile.addons
+++ b/dockerfiles/Dockerfile.addons
@@ -1,4 +1,5 @@
 FROM node:18.15
-COPY package.json /usr/src/app/addons/
-WORKDIR /usr/src/app/addons/
+COPY package-lock.json /usr/src/app/checkouts/addons/
+COPY package.json /usr/src/app/checkouts/addons/
+WORKDIR /usr/src/app/checkouts/addons/
 RUN npm install

--- a/dockerfiles/Dockerfile.webpack
+++ b/dockerfiles/Dockerfile.webpack
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:22.11
 COPY package-lock.json /usr/src/app/checkouts/ext-theme/
 COPY package.json /usr/src/app/checkouts/ext-theme/
 WORKDIR /usr/src/app/checkouts/ext-theme

--- a/dockerfiles/Dockerfile.webpack
+++ b/dockerfiles/Dockerfile.webpack
@@ -1,0 +1,5 @@
+FROM node:16
+COPY package-lock.json /usr/src/app/checkouts/ext-theme/
+COPY package.json /usr/src/app/checkouts/ext-theme/
+WORKDIR /usr/src/app/checkouts/ext-theme
+RUN npm install

--- a/dockerfiles/docker-compose-webpack.yml
+++ b/dockerfiles/docker-compose-webpack.yml
@@ -4,13 +4,16 @@
 services:
 
   webpack:
-    image: node:16
+    build:
+      context: ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}
+      dockerfile: ${PWD}/common/dockerfiles/Dockerfile.webpack
     working_dir: /usr/src/app/checkouts/ext-theme
     ports:
       - "10001:10001"
     volumes:
-      - ${PWD}/common/dockerfiles/entrypoints/webpack.sh:/usr/src/app/docker/webpack.sh
-      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/src:/usr/src/app/checkouts/ext-theme/src
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/readthedocsext:/usr/src/app/checkouts/ext-theme/readthedocsext
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/webpack.config.mjs:/usr/src/app/checkouts/ext-theme/webpack.config.mjs
     environment:
       - INIT=${INIT:-}
       - DOCKER_NO_RELOAD
@@ -21,4 +24,9 @@ services:
     tty: true
     networks:
       readthedocs:
-    command: ["../../docker/webpack.sh"]
+    command: [
+      "./node_modules/.bin/webpack-dev-server",
+      "--mode=development",
+      "--host=0.0.0.0",
+      "--port=10001",
+    ]

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -56,9 +56,10 @@ services:
     networks:
       readthedocs:
     volumes:
-      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/src/:/usr/src/app/addons/src/
-      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/webpack.config.js/:/usr/src/app/addons/webpack.config.js
-    working_dir: /usr/src/app/addons/
+      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/src/:/usr/src/app/checkouts/addons/src/
+      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/webpack.config.js/:/usr/src/app/checkouts/addons/webpack.config.js
+    tty: true
+    working_dir: /usr/src/app/checkouts/addons/
     ports:
       - "8000:8000"
     command: [

--- a/dockerfiles/entrypoints/webpack.sh
+++ b/dockerfiles/entrypoints/webpack.sh
@@ -1,8 +1,0 @@
-#! /bin/sh
-
-npm ci
-
-$(npm bin)/webpack-dev-server \
-  --mode=development \
-  --host=0.0.0.0 \
-  --port=10001


### PR DESCRIPTION
- Install webpack dependencies inside the Docker image
- Do not call `npm ci` for webpack at startup
- Mount addons volume under `checkouts/` as other containers
- Mount only required directories/files for ext-theme