### PR TITLE
Development: use `--build-arg` to invalidate cache

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     build:
       context: ${PWD}
       dockerfile: ${PWD}/dockerfiles/Dockerfile
+      args:
+        PRUNE_PYTHON_PACKAGE_CACHE: ${PRUNE_PYTHON_PACKAGE_CACHE:-0}
 
   nginx:
     stop_grace_period: 1s

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -16,7 +16,6 @@ DOCKER_COMPOSE_COMMAND = f'docker compose --project-directory=. -f {DOCKER_COMPO
 def build(c, cache=False):
     """Build docker image for servers."""
     cache_opt = '--no-cache'
-    cache_hash = ""
     build_arg = ""
     if cache:
         cache_opt = ""
@@ -33,12 +32,12 @@ def build(c, cache=False):
             "../readthedocs-ext/setup.cfg",
         ]
 
+        cache_hash = hashlib.md5()
         for f in files_to_cache:
             if os.path.exists(f):
-                cache_hash += hashlib.md5(open(f, mode="rb").read()).hexdigest()
-
-    if cache_hash:
-        build_arg = f"--build-arg PRUNE_PACKAGE_CACHE={cache_hash}"
+                cache_hash.update(open(f, mode="rb").read())
+        cache_hash = cache_hash.hexdigest()
+        build_arg = f"--build-arg PRUNE_PYTHON_PACKAGE_CACHE={cache_hash}"
 
     c.run(f'{DOCKER_COMPOSE_COMMAND} build {cache_opt} {build_arg}', echo=True, pty=True)
 

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -15,10 +15,9 @@ DOCKER_COMPOSE_COMMAND = f'docker compose --project-directory=. -f {DOCKER_COMPO
 })
 def build(c, cache=False):
     """Build docker image for servers."""
-    cache_opt = '--no-cache'
-    build_arg = ""
-    if cache:
-        cache_opt = ""
+    cache_opt = '--no-cache' if not cache else ""
+    cache_env_var = ""
+    if cache and not os.environ.get("PRUNE_PYTHON_PACKAGE_CACHE"):
         files_to_cache = [
             # Community
             "requirements/docker.txt",
@@ -37,9 +36,9 @@ def build(c, cache=False):
             if os.path.exists(f):
                 cache_hash.update(open(f, mode="rb").read())
         cache_hash = cache_hash.hexdigest()
-        build_arg = f"--build-arg PRUNE_PYTHON_PACKAGE_CACHE={cache_hash}"
+        cache_env_var = f"PRUNE_PYTHON_PACKAGE_CACHE={cache_hash}"
 
-    c.run(f'{DOCKER_COMPOSE_COMMAND} build {cache_opt} {build_arg}', echo=True, pty=True)
+    c.run(f'{cache_env_var} {DOCKER_COMPOSE_COMMAND} build {cache_opt}', echo=True, pty=True)
 
 @task(help={
     'command': 'Command to pass directly to "docker compose"',


### PR DESCRIPTION
Create a hash of all the dependencies files and use it as a `--build-arg` to invalidate the cache when the hash changes.

Related https://github.com/readthedocs/common/pull/241
Related https://github.com/readthedocs/readthedocs.org/pull/11816