### PR TITLE
Development: mount NPM dependencies files

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       readthedocs:
     volumes:
       - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/src/:/usr/src/app/checkouts/addons/src/
+      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/package.json/:/usr/src/app/checkouts/addons/package.json
+      - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/package-lock.json/:/usr/src/app/checkouts/addons/package-lock.json
       - ${PWD}/${RTDDEV_PATH_ADDONS:-../addons}/webpack.config.js/:/usr/src/app/checkouts/addons/webpack.config.js
     tty: true
     working_dir: /usr/src/app/checkouts/addons/
@@ -159,6 +161,8 @@ services:
     volumes:
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/src:/usr/src/app/checkouts/ext-theme/src
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/readthedocsext:/usr/src/app/checkouts/ext-theme/readthedocsext
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/packages.json:/usr/src/app/checkouts/ext-theme/packages.json
+      - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/packages-lock.json:/usr/src/app/checkouts/ext-theme/packages-lock.json
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}/webpack.config.mjs:/usr/src/app/checkouts/ext-theme/webpack.config.mjs
     environment:
       - INIT=${INIT:-}


### PR DESCRIPTION
This is to allow installing dependencies from inside the container and perform the changes in the `package.json` files from the respository itself; so we can push these changes remotely after installing a new dependency.

Covers this use case
https://github.com/readthedocs/common/issues/245#issuecomment-2519778470