### PR TITLE
Restart Docker containers if readthedocs-ext code changes

### DIFF
--- a/dockerfiles/nodemon.json
+++ b/dockerfiles/nodemon.json
@@ -2,7 +2,7 @@
     "verbose": false,
     "delay": 2000,
     "ext": "py",
-    "watch": ["readthedocs", "readthedocsinc", "../readthedocs.org/readthedocs"],
+    "watch": ["readthedocs", "readthedocsinc", "../readthedocs.org/readthedocs", "../readthedocs-ext/readthedocsext"],
     "ignore": [".tox/*", ".direnv/*", "user_builds/*", "*/management/commands*", "*migrations/*", "*test*", "*.pyc", "*.pyo", "logs/*"],
     "signal": "SIGTERM"
 }


### PR DESCRIPTION
I was bitten by this a lot this week. Now, changing code in readthedocs-ext will restart the containers.