### PR TITLE
Upgrade Postgres to 16.3 to match prdouction

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -1,7 +1,7 @@
 volumes:
   build-user-builds:
   storage_data:
-  postgres_data:
+  postgres_data_16:
   postgres_backups_data:
 
 services:
@@ -305,14 +305,14 @@ services:
       readthedocs:
 
   database:
-    image: postgres:12.17
+    image: postgres:16.3
     environment:
       - POSTGRES_USER=docs_user
       - POSTGRES_PASSWORD=docs_pwd
       - POSTGRES_DB=docs_db
     volumes:
       - ${PWD}/common/dockerfiles/entrypoints/postgres.sql:/docker-entrypoint-initdb.d/postgres.sql
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data_16:/var/lib/postgresql/data
       - postgres_backups_data:/backups
     networks:
       readthedocs:

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -131,6 +131,13 @@ def manage(c, command, running=True, backupdb=False):
     if running:
         subcmd = 'exec'
 
+    # After you run this and upgrade the DB:
+    # inv docker.shell --container database --no-running
+    # dropdb -U docs_user docs_db
+    # createdb -U docs_user docs_db
+    # psql -U docs_user docs_db < dump_*.sql
+    # If upgrading Postgres versions, you may need to run:
+    # ALTER USER docs_user WITH ENCRYPTED PASSWORD 'docs_pwd';
     if backupdb:
         c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} database pg_dumpall -c -U docs_user > dump_`date +%d-%m-%Y"_"%H_%M_%S`__`git rev-parse HEAD`.sql', pty=True)
 


### PR DESCRIPTION
This requires a couple changes:

* Before applying this, you can backup your data with ``inv docker.manage --backupdb shell``. Confirm it worked with `!ls`, which should show a `dump_*.sql` file
* If you keep the same data dir, postgres gets annoyed about the data dir being old, so this swaps a new one.
* After applying, you can run:

```
    inv docker.shell --container database --no-running

    # from another shell
    docker cp dump_*.sql community_database_1:/tmp/dump.sql

   # From inside container
    createdb -U docs_user docs_db
    psql -U docs_user docs_db < dump_*.sql
    psql -U docs_user ALTER USER docs_user WITH ENCRYPTED PASSWORD 'docs_pwd';
```
