### PR TITLE
Run application from `uv`

### DIFF
--- a/dockerfiles/entrypoints/build.sh
+++ b/dockerfiles/entrypoints/build.sh
@@ -9,7 +9,7 @@
 # Ref https://docs.celeryq.dev/en/stable/userguide/workers.html#persistent-revokes.
 CELERY_STATE_DIR=/var/run/celery/
 mkdir -p $CELERY_STATE_DIR
-CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l ${CELERY_LOG_LEVEL} --statedb=${CELERY_STATE_DIR}worker.state"
+CMD="uv run python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 1 -Q builder,celery,default,build01,build:default,build:large -l ${CELERY_LOG_LEVEL} --statedb=${CELERY_STATE_DIR}worker.state"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/celery-beat.sh
+++ b/dockerfiles/entrypoints/celery-beat.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker beat -l ${CELERY_LOG_LEVEL}"
+CMD="uv run python3 -m celery -A ${CELERY_APP_NAME}.worker beat -l ${CELERY_LOG_LEVEL}"
 
 # Not sure why, but the db becomes corrupted at some point
 # and make the startup of this process to fail.

--- a/dockerfiles/entrypoints/celery.sh
+++ b/dockerfiles/entrypoints/celery.sh
@@ -8,7 +8,7 @@ if [ "$SEARCH" != "" ]; then
   ../../docker/wait-for-it.sh search:9200 --timeout=180 --strict
 fi
 
-CMD="python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 2 -Q web,web01,reindex,autoscaling -l ${CELERY_LOG_LEVEL}"
+CMD="uv run python3 -m celery -A ${CELERY_APP_NAME}.worker worker -Ofair -c 2 -Q web,web01,reindex,autoscaling -l ${CELERY_LOG_LEVEL}"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/common.sh
+++ b/dockerfiles/entrypoints/common.sh
@@ -10,5 +10,3 @@ echo 'Executing common.sh'
 
 # Reinstall all the dependencies without rebuilding the image
 # pip install -r requirements.txt
-
-uv pip install -U celery setuptools

--- a/dockerfiles/entrypoints/common.sh
+++ b/dockerfiles/entrypoints/common.sh
@@ -10,3 +10,5 @@ echo 'Executing common.sh'
 
 # Reinstall all the dependencies without rebuilding the image
 # pip install -r requirements.txt
+
+uv pip install -U celery setuptools

--- a/dockerfiles/entrypoints/proxito.sh
+++ b/dockerfiles/entrypoints/proxito.sh
@@ -2,7 +2,7 @@
 
 ../../docker/common.sh
 
-CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
+CMD="uv run gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -6,14 +6,14 @@ if [ -n "$INIT" ];
 then
     echo "Performing initial tasks..."
     ../../docker/createbuckets.sh
-    python3 manage.py migrate
-    python3 manage.py migrate --database telemetry
-    cat ../../docker/createsuperuser.py | python3 manage.py shell
-    python3 manage.py collectstatic --no-input
-    python3 manage.py loaddata test_data
+    uv run python3 manage.py migrate
+    uv run python3 manage.py migrate --database telemetry
+    cat ../../docker/createsuperuser.py | uv run python3 manage.py shell
+    uv python3 manage.py collectstatic --no-input
+    uv run python3 manage.py loaddata test_data
 fi
 
-CMD="gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
+CMD="uv run gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"

--- a/dockerfiles/tasks.py
+++ b/dockerfiles/tasks.py
@@ -141,7 +141,7 @@ def manage(c, command, running=True, backupdb=False):
     if backupdb:
         c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} database pg_dumpall -c -U docs_user > dump_`date +%d-%m-%Y"_"%H_%M_%S`__`git rev-parse HEAD`.sql', pty=True)
 
-    c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} web python3 manage.py {command}', pty=True)
+    c.run(f'{DOCKER_COMPOSE_COMMAND} {subcmd} web uv run python3 manage.py {command}', pty=True)
 
 @task(help={
     'container': 'Container to attach',
@@ -196,7 +196,7 @@ def test(c, arguments='', running=True):
 def buildassets(c):
     """Build all assets for the application and push them to backend storage"""
     c.run(f'docker compose -f {DOCKER_COMPOSE_ASSETS} run --rm assets bash -c "npm ci && node_modules/bower/bin/bower --allow-root update && npm run build"', pty=True)
-    c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web python3 manage.py collectstatic --noinput', pty=True)
+    c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web uv run python3 manage.py collectstatic --noinput', pty=True)
 
 
 @task(help={
@@ -221,13 +221,13 @@ def translations(c, action):
 
     if action == 'pull':
         c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web ./tx --token {transifex_token} pull --force', pty=True)
-        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && python3 ../manage.py makemessages --all"', pty=True)
-        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && python3 ../manage.py compilemessages"', pty=True)
+        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && uv run python3 ../manage.py makemessages --all"', pty=True)
+        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && uv run python3 ../manage.py compilemessages"', pty=True)
 
     elif action == 'push':
-        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && python3 ../manage.py makemessages --locale en"', pty=True)
+        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && uv run python3 ../manage.py makemessages --locale en"', pty=True)
         c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web ./tx --token {transifex_token} push --source', pty=True)
-        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && python3 ../manage.py compilemessages --locale en"', pty=True)
+        c.run(f'{DOCKER_COMPOSE_COMMAND} run --rm web /bin/bash -c "cd readthedocs/ && uv run python3 ../manage.py compilemessages --locale en"', pty=True)
 
 
 @task(help={


### PR DESCRIPTION
When running on Ubuntu 24.04, we cannot use `--system` anymore because pip complains about it. I understand we are forced to create a virtualenv when creating the Docker image.

Due to that, we need to run our application using that virtualenv we created at build time. We use `uv run` for that.

Required by https://github.com/readthedocs/readthedocs.org/pull/12002