### PR TITLE
Restore previous ES option

### DIFF
--- a/dockerfiles/docker-compose-search.yml
+++ b/dockerfiles/docker-compose-search.yml
@@ -26,9 +26,7 @@ services:
       - ELASTIC_PASSWORD=password
       # Disable HTTPS on development.
       - xpack.security.transport.ssl.enabled=false
-      # Make search work on MacOS
-      - 'ES_JAVA_OPTS=-Xms128m -Xmx128m -XX:UseSVE=0'
-      - 'CLI_JAVA_OPTS=-XX:UseSVE=0'
+      - 'ES_JAVA_OPTS=-Xms128m -Xmx128m'
     ports:
       - "9200:9200"
     links:


### PR DESCRIPTION
This breaks ES, as -XX:UseSVE isn't recognized as a valid Java option.

Ref https://github.com/readthedocs/common/pull/270