### PR TITLE
Fix bad pre-commit config

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -67,8 +67,7 @@ repos:
     # Run the formatter.
     - id: ruff-format
 
-repos:
-  - repo: https://github.com/errata-ai/vale
-    rev: v3.12.0
-    hooks:
-      - id: vale
+- repo: https://github.com/errata-ai/vale
+  rev: v3.12.0
+  hooks:
+    - id: vale


### PR DESCRIPTION
We replaced all of `repos` key with the last update, this removed all other repo configurations.