### PR TITLE
Add codespell config and pre-commit hook

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,15 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,*.svg,*.css,*.min.*,*.ai,locale,package-lock.json,vendor,migrations,CHANGELOG.rst,common,media/javascript,*/search/tests/data/*,.codespellrc
+check-hidden = true
+# Ignore camelCase and PascalCase identifiers, URLs, and very long lines (minified)
+# Also: specific patterns in test fixtures and docs examples
+ignore-regex = \b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b|https?://\S+|.{300,}|"pyton\b|\|(ative|ment)\||"Hel" will match\b|ative: ''|help_text *=.*|\bOre\b|\bWile E\. Coyote\b|\bre-(used?|using|declare)\b|\bpre-selected\b
+# fo,te - ISO 639 language codes (Faroese, Telugu)
+# astroid - Python AST library name
+# requestor - used in RTD codebase
+# syntaxt - Django model field, changing requires DB migration
+# DED - Django Elasticsearch DSL abbreviation
+# indx - intentional non-matching search query in tests
+# ore - used in example diff output
+ignore-words-list = fo,te,astroid,requestor,syntaxt,DED,indx,ore

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -67,6 +67,12 @@ repos:
     # Run the formatter.
     - id: ruff-format
 
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in .codespellrc (symlinked from common/)
+  rev: v2.4.1
+  hooks:
+    - id: codespell
+
 - repo: https://github.com/errata-ai/vale
   rev: v3.13.0
   hooks:


### PR DESCRIPTION
- Added .codespellrc with comprehensive skip/ignore patterns
- Added codespell to pre-commit-config.yaml
- Skips: locale, migrations, CHANGELOG, media/javascript, test data, SVG/CSS/AI/minified files
- Ignores: ISO 639 codes (fo, te), library names (astroid, DED), Django model fields (syntaxt), test fixtures (indx, pyton)

it is a reincarnated
- #212 

and needed for
- https://github.com/readthedocs/readthedocs.org/pull/11195