### PR TITLE
Fix django-debug-toolbar by reducing worker count

### DIFF
--- a/dockerfiles/entrypoints/web.sh
+++ b/dockerfiles/entrypoints/web.sh
@@ -13,7 +13,7 @@ then
     uv run python3 manage.py loaddata test_data
 fi
 
-CMD="uv run gunicorn readthedocs.wsgi:application -w 3 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
+CMD="uv run gunicorn readthedocs.wsgi:application -w 1 -b 0.0.0.0:8000 --max-requests=10000 --timeout=0"
 
 if [ -n "${DOCKER_NO_RELOAD}" ]; then
   echo "Running process with no reload"


### PR DESCRIPTION
Debug toolbar has been pretty useless for a long time now, all pages in
the toolbar mostly show failures and only work a small portion of the
time. Reducing the worker count resolves this behavior and allows all
pages to function.

There might be a longer term fix here, the problem is likely the workers
not sharing some state that debug toolbar is expecting.