### PR TITLE
Update dockerfile node as well to match nodejs upgrade to 24.16

### DIFF
--- a/dockerfiles/Dockerfile.addons
+++ b/dockerfiles/Dockerfile.addons
@@ -1,4 +1,4 @@
-FROM node:22.16.0
+FROM node:24.16.0
 COPY package-lock.json /usr/src/app/checkouts/addons/
 COPY package.json /usr/src/app/checkouts/addons/
 WORKDIR /usr/src/app/checkouts/addons/

--- a/dockerfiles/Dockerfile.webpack
+++ b/dockerfiles/Dockerfile.webpack
@@ -1,4 +1,4 @@
-FROM node:22.11
+FROM node:24.16.0
 COPY package-lock.json /usr/src/app/checkouts/ext-theme/
 COPY package.json /usr/src/app/checkouts/ext-theme/
 WORKDIR /usr/src/app/checkouts/ext-theme


### PR DESCRIPTION
Missed these, another good point for keeping the Dockerfile in the individual repositories instead of separate in this repo.