### PR TITLE
Agents: trim boilerplate that agents already follow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,8 @@ It supports multiple documentation tools (Sphinx, MkDocs, etc.) and automaticall
 
 ## Testing
 
-- Use `pytest` as the testing framework
-- Use the `assert foo == bar` style for assertions
-- Write succinct, focused tests that test one thing at a time
-- Use descriptive test names that explain what is being tested
-- Place tests in appropriate test files following the project structure
-- Always keep the test db with ``pytest --reuse-db`` to speed up test runs
+- Use `pytest` with the `assert foo == bar` assertion style
+- Keep the test DB warm with `pytest --reuse-db` to speed up runs
 
 ### Running tests locally
 
@@ -90,19 +86,6 @@ Always run `tox -e migrations` after adding or modifying migration files. This r
 `manage.py makemigrations --check --dry-run` and catches missing or inconsistent migrations
 before they cause `IntegrityError` failures at deploy time.
 
-## Code Quality
-
-- Follow PEP 8 style guidelines
-- Use Django conventions and best practices
-- Use type hints for function signatures
-- Write clear, concise docstrings for public functions and classes
-
 ## Front-end
 
 - Most templates/css/js are in a separate repository (https://github.com/readthedocs/ext-theme/).
-
-## Security
-
-- Follow Django security best practices
-- Be aware of OWASP top 10 vulnerabilities
-- Use Django's built-in security features (CSRF, XSS protection, etc.)


### PR DESCRIPTION
HS: I asked the agent how to improve the Agent file, and this is what it came up with. And they can make sense, we should only be stating things that are unique to our codebase. It knows to follow the existing style.

`AGENTS.md` tells agents to cut filler, then spends whole sections on advice any competent agent already follows — PEP 8, "be aware of OWASP", "write descriptive test names." That boilerplate buries the rules that are genuinely RTD-specific and easy to get wrong (the `tox` recipes, the migration check, the marketing-names rule). Removing it so the guidance that remains is worth reading.

If any of the dropped sections was load-bearing for a reason I'm missing, say so and I'll restore it — ideally replaced with a concrete, RTD-specific rule rather than a placeholder.

Stacked on #307 to avoid conflicts on the same file; rebase onto `main` once that lands.