### PR TITLE
Several fixes for docker builds and Node.js

### DIFF
--- a/dockerfiles/Dockerfile.addons
+++ b/dockerfiles/Dockerfile.addons
@@ -1,4 +1,4 @@
-FROM node:22.16.0
+FROM node:24.16.0
 COPY package-lock.json /usr/src/app/checkouts/addons/
 COPY package.json /usr/src/app/checkouts/addons/
 WORKDIR /usr/src/app/checkouts/addons/

--- a/dockerfiles/Dockerfile.webpack
+++ b/dockerfiles/Dockerfile.webpack
@@ -1,4 +1,4 @@
-FROM node:22.11
+FROM node:24.16.0
 COPY package-lock.json /usr/src/app/checkouts/ext-theme/
 COPY package.json /usr/src/app/checkouts/ext-theme/
 WORKDIR /usr/src/app/checkouts/ext-theme

--- a/packages/addons-inject/package.json
+++ b/packages/addons-inject/package.json
@@ -18,7 +18,6 @@
   "author": "Read the Docs, Inc",
   "license": "MIT",
   "dependencies": {
-    "//": "wrangler is pinned: 4.20+ rewrites inbound Host and X-Forwarded-Host to the value of `dev --host`, which breaks subdomain-based project resolution in El Proxito for local development",
     "wrangler": "4.19.1"
   },
   "devDependencies": {


### PR DESCRIPTION

- Use Node.js 24.16.0 for images
- Drop comment in package.json, it throws an exception and blocks building
