### PR TITLE
Extra changes for isolated builders on local development

### DIFF
--- a/dockerfiles/Dockerfile.isolated-builder
+++ b/dockerfiles/Dockerfile.isolated-builder
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         docker.io \
         nodejs \
         npm \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Symlink so ``python`` works without a version suffix (matches the AMI,
@@ -48,6 +49,23 @@ RUN ln -sf /usr/bin/python3.14 /usr/local/bin/python
 # Install uv at the same path the AMI uses (/usr/local/bin/uv) so the
 # entrypoint script is identical to the production setup unit.
 RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
+
+# rclone, at the same path and version the AMI bakes in (see
+# readthedocs-builder/packer/builder.pkr.hcl's ``rclone_version``). The runner
+# syncs build artifacts to storage with it, from inside the build container.
+#
+# The entrypoint copies this onto a host-visible bind-mount so the worker can
+# pass it to ``docker run -v``: the worker runs in THIS container, but the
+# daemon resolving that mount is the host's, so a path that only exists here
+# would not resolve. See the entrypoint + RTD_HOST_RCLONE_PATH in
+# docker-compose.yml.
+ARG RTD_RCLONE_VERSION=1.60.1
+RUN curl -fsSL -o /tmp/rclone.zip \
+        "https://downloads.rclone.org/v${RTD_RCLONE_VERSION}/rclone-v${RTD_RCLONE_VERSION}-linux-amd64.zip" \
+    && cd /tmp && unzip -q rclone.zip \
+    && install -m 0755 "/tmp/rclone-v${RTD_RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone \
+    && rm -rf /tmp/rclone.zip "/tmp/rclone-v${RTD_RCLONE_VERSION}-linux-amd64" \
+    && rclone version
 
 # Install nodemon globally so the entrypoint can optionally run the
 # Celery worker with reload (dev-only, not in the AMI).
@@ -60,7 +78,7 @@ RUN npm install -g nodemon
 # uv (host paths, like production, so the worker can re-mount them
 # into build containers). The entrypoint also populates
 # /usr/src/builder/worker-venv (container-local).
-RUN mkdir -p /usr/src/builder/checkouts/readthedocs-builder /usr/src/builder/runner-venv /usr/src/builder/uv-python /usr/src/builder/worker-venv
+RUN mkdir -p /usr/src/builder/checkouts/readthedocs-builder /usr/src/builder/runner-venv /usr/src/builder/uv-python /usr/src/builder/worker-venv /usr/src/builder/rclone
 
 WORKDIR /usr/src/builder/checkouts/readthedocs-builder
 

--- a/dockerfiles/Dockerfile.isolated-builder
+++ b/dockerfiles/Dockerfile.isolated-builder
@@ -10,7 +10,7 @@
 #
 # What this image installs corresponds to the Packer template's
 # bake-time steps:
-#   - git, python3.14, ca-certificates                (AL2023 base + dnf step)
+#   - git, openssh-client, python3.14, ca-certificates (AL2023 base + dnf step)
 #   - docker CLI                                      (docker-in-docker for build dispatch)
 #   - uv at /usr/local/bin/uv                         (same path as the AMI)
 #   - empty /usr/src/builder/checkouts/readthedocs-builder +
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
+        openssh-client \
         python3.14 \
         python3.14-venv \
         docker.io \

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -128,6 +128,9 @@ services:
       - ${PWD}/common/dockerfiles/nodemon.json:/usr/src/app/checkouts/nodemon.json
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
+
+      # Docker in Docker: cancel running builds.
+      - /var/run/docker.sock:/var/run/docker.sock
     links:
       - storage
       - database
@@ -215,7 +218,7 @@ services:
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
 
-      # Docker in Docker
+      # Docker in Docker: Fargate (call `docker run` from inside `web` queue)
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - storage
@@ -331,7 +334,7 @@ services:
       # Because of this, we need to use a shared volume between them
       - build-user-builds:/usr/src/app/checkouts/readthedocs.org/user_builds
 
-      # Docker in Docker
+      # Docker in Docker: old implementation (`build-default` queue)
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - web

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -403,8 +403,10 @@ services:
       # image). Bind-mounted onto PATH inside each build container.
       - RTD_HOST_RCLONE_PATH=${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/rclone/rclone
       # Have build containers join the compose network so they can
-      # reach the API at ``http://web`` via service-name DNS.
-      - RTD_BUILD_NETWORK=community_readthedocs
+      # reach the API at ``http://web`` via service-name DNS. Derived from the
+      # compose project so it's correct for both community (``community``) and
+      # commercial (``commercial``) — a hardcoded value breaks the other env.
+      - RTD_BUILD_NETWORK=${COMPOSE_PROJECT_NAME}_readthedocs
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -214,6 +214,9 @@ services:
       - ${PWD}/common/dockerfiles/nodemon.json:/usr/src/app/checkouts/nodemon.json
       - ${PWD}/${RTDDEV_PATH_EXT:-../readthedocs-ext}:/usr/src/app/checkouts/readthedocs-ext
       - ${PWD}/${RTDDEV_PATH_EXT_THEME:-../ext-theme}:/usr/src/app/checkouts/ext-theme
+
+      # Docker in Docker
+      - /var/run/docker.sock:/var/run/docker.sock
     links:
       - storage
       - database
@@ -256,6 +259,7 @@ services:
       - RTD_S3_STATIC_STORAGE_BUCKET
       - RTD_AWS_S3_REGION_NAME
       - RTD_OPENAI_API_KEY
+      - RTD_BUILDER_TOKEN
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -373,6 +373,9 @@ services:
       - ${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}:/usr/src/builder/checkouts/readthedocs-builder
       - ${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/runner-venv:/usr/src/builder/runner-venv
       - ${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/uv-python:/usr/src/builder/uv-python
+      # The entrypoint copies the image's rclone here so the host daemon
+      # can bind-mount it into the build containers the worker spawns.
+      - ${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/rclone:/usr/src/builder/rclone
       - ${PWD}/common/dockerfiles/entrypoints/isolated-builder.sh:/usr/src/builder/docker/isolated-builder.sh
       - ${PWD}/common/dockerfiles/nodemon.json:/usr/src/builder/checkouts/nodemon.json
 
@@ -396,6 +399,9 @@ services:
       # same directories bind-mounted into this service above).
       - RTD_HOST_RUNNER_VENV_PATH=${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/runner-venv
       - RTD_HOST_PYTHON_INSTALL_PATH=${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/uv-python
+      # rclone binary, host-visible (the entrypoint copies it out of the
+      # image). Bind-mounted onto PATH inside each build container.
+      - RTD_HOST_RCLONE_PATH=${PWD}/${RTDDEV_PATH_BUILDER:-../readthedocs-builder}/rclone/rclone
       # Have build containers join the compose network so they can
       # reach the API at ``http://web`` via service-name DNS.
       - RTD_BUILD_NETWORK=community_readthedocs

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -390,7 +390,7 @@ services:
       - RTD_DOCKER_COMPOSE=1
       - RTD_BROKER_URL=redis://:redispassword@cache:6379/0
       - RTD_BUILDS_QUEUE=isolated-builds
-      - RTD_BUILDER_REF=celery-on-ec2
+      - RTD_BUILDER_REF=main
       # Source path the worker passes to ``docker run -v ...`` when
       # spawning build containers. Must be a HOST-visible path because
       # the daemon resolves it on the host.

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -388,6 +388,7 @@ services:
       - web
     environment:
       - DOCKER_NO_RELOAD
+      - RTD_DOCKER_COMPOSE=1
       - RTD_BROKER_URL=redis://:redispassword@cache:6379/0
       - RTD_BUILDS_QUEUE=isolated-builds
       - RTD_BUILDER_REF=celery-on-ec2
@@ -405,9 +406,6 @@ services:
       # Have build containers join the compose network so they can
       # reach the API at ``http://web`` via service-name DNS.
       - RTD_BUILD_NETWORK=community_readthedocs
-      # Skip the EC2 IMDS metadata fetch + AWS terminate call on
-      # task_postrun (we're obviously not on EC2).
-      - RTD_SKIP_SELF_TERMINATE=1
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -263,6 +263,7 @@ services:
       - RTD_AWS_S3_REGION_NAME
       - RTD_OPENAI_API_KEY
       - RTD_BUILDER_TOKEN
+      - RTD_PATH_BUILDER
     stdin_open: true
     tty: true
     networks:

--- a/dockerfiles/entrypoints/isolated-builder.sh
+++ b/dockerfiles/entrypoints/isolated-builder.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # Optional variables with defaults
 : "${RTD_BUILDS_QUEUE:=isolated-builds}"
 : "${RTD_BUILDER_REPO:=https://github.com/readthedocs/readthedocs-builder.git}"
-: "${RTD_BUILDER_REF:=celery-on-ec2}"
+: "${RTD_BUILDER_REF:=main}"
 : "${RTD_BUILDER_TOKEN:=}"
 
 SRC="/usr/src/builder/checkouts/readthedocs-builder"

--- a/dockerfiles/entrypoints/isolated-builder.sh
+++ b/dockerfiles/entrypoints/isolated-builder.sh
@@ -25,6 +25,7 @@ SRC="/usr/src/builder/checkouts/readthedocs-builder"
 RUNNER_VENV="/usr/src/builder/runner-venv"
 UV_PYTHON_DIR="/usr/src/builder/uv-python"
 WORKER_VENV="/usr/src/builder/worker-venv"
+RCLONE_DIR="/usr/src/builder/rclone"
 
 # 1. Clone (or skip if the host's checkout is bind-mounted in).
 #    A bind-mount means $SRC is already populated; we skip ``git clone``
@@ -39,6 +40,24 @@ if [ -z "$(ls -A "$SRC" 2>/dev/null)" ]; then
     git clone --depth=1 --branch "$RTD_BUILDER_REF" "$clone_url" "$SRC"
 else
     echo "[isolated-builder] $SRC already populated; skipping clone (dev bind-mount)."
+fi
+
+# 1b. Copy the image's rclone onto the host-visible bind-mount.
+#     The runner syncs artifacts to storage with rclone from inside the
+#     build container, and the worker bind-mounts the binary in rather
+#     than each build downloading its own. In production Packer bakes
+#     rclone into the AMI, so the worker mounts a real host path.
+#
+#     Here the worker runs in THIS container, but ``docker run -v`` is
+#     resolved by the HOST daemon (docker-out-of-docker via the mounted
+#     socket) — so /usr/local/bin/rclone from this image is invisible to
+#     it. Copying into $RCLONE_DIR (a host bind-mount, see compose) puts
+#     the binary on the host filesystem, same trick as $RUNNER_VENV.
+if [ ! -x "$RCLONE_DIR/rclone" ]; then
+    echo "[isolated-builder] Copying rclone to $RCLONE_DIR (host-visible for build containers) ..."
+    install -m 0755 /usr/local/bin/rclone "$RCLONE_DIR/rclone"
+else
+    echo "[isolated-builder] $RCLONE_DIR/rclone already present; skipping."
 fi
 
 # 2. Pre-build the runner venv against a uv-managed Python 3.14 by


### PR DESCRIPTION
- ~**Mount rclone inside the container**: this is required because we are uploading the artifacts from inside the builder now. The `readthedocs/build:<os>` image doesn't have `rclone` installed. Instead of rebuilding all those images, the easiest solution is to install rclone in the image spinning up the Docker container and mount the binary there. *NOTE: we can find another way to do this later, but I want to have a solution in place for now. This is easiest one that I found.*~
- **Install rclone** inside the Docker image
- **Mount Docker socket**: this is required to allow the container to kill Docker containers
- **Pass extra environment variables**
- **Install `ssh`**: to be able to clone private repositories